### PR TITLE
Remove strings.ToLower

### DIFF
--- a/pkg/devfile/parser/data/v2/projects.go
+++ b/pkg/devfile/parser/data/v2/projects.go
@@ -1,8 +1,6 @@
 package v2
 
 import (
-	"strings"
-
 	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 )
@@ -33,7 +31,7 @@ func (d *DevfileV2) AddProjects(projects []v1.Project) error {
 // UpdateProject updates the slice of Devfile projects parsed from the Devfile
 func (d *DevfileV2) UpdateProject(project v1.Project) {
 	for i := range d.Projects {
-		if d.Projects[i].Name == strings.ToLower(project.Name) {
+		if d.Projects[i].Name == project.Name {
 			d.Projects[i] = project
 		}
 	}
@@ -65,7 +63,7 @@ func (d *DevfileV2) AddStarterProjects(projects []v1.StarterProject) error {
 // UpdateStarterProject updates the slice of Devfile starter projects parsed from the Devfile
 func (d *DevfileV2) UpdateStarterProject(project v1.StarterProject) {
 	for i := range d.StarterProjects {
-		if d.StarterProjects[i].Name == strings.ToLower(project.Name) {
+		if d.StarterProjects[i].Name == project.Name {
 			d.StarterProjects[i] = project
 		}
 	}

--- a/pkg/devfile/parser/devfileobj.go
+++ b/pkg/devfile/parser/devfileobj.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	devfileCtx "github.com/devfile/library/pkg/devfile/parser/context"
@@ -35,7 +34,7 @@ func (d DevfileObj) OverrideComponents(overridePatch []v1.ComponentParentOverrid
 	for _, patchComponent := range overridePatch {
 		found := false
 		for _, originalComponent := range d.Data.GetComponents() {
-			if strings.ToLower(patchComponent.Name) == originalComponent.Name {
+			if patchComponent.Name == originalComponent.Name {
 				found = true
 
 				var updatedComponent v1.ContainerComponent
@@ -71,7 +70,7 @@ func (d DevfileObj) OverrideCommands(overridePatch []v1.CommandParentOverride) (
 		found := false
 		for _, originalCommand := range d.Data.GetCommands() {
 
-			if strings.ToLower(patchCommand.Id) == originalCommand.Id {
+			if patchCommand.Id == originalCommand.Id {
 				found = true
 
 				var devfileCommand v1.Command
@@ -152,7 +151,7 @@ func (d DevfileObj) OverrideProjects(overridePatch []v1.ProjectParentOverride) e
 	for _, patchProject := range overridePatch {
 		found := false
 		for _, originalProject := range d.Data.GetProjects() {
-			if strings.ToLower(patchProject.Name) == originalProject.Name {
+			if patchProject.Name == originalProject.Name {
 				found = true
 				var updatedProject v1.Project
 
@@ -182,7 +181,7 @@ func (d DevfileObj) OverrideStarterProjects(overridePatch []v1.StarterProjectPar
 	for _, patchProject := range overridePatch {
 		found := false
 		for _, originalProject := range d.Data.GetStarterProjects() {
-			if strings.ToLower(patchProject.Name) == originalProject.Name {
+			if patchProject.Name == originalProject.Name {
 				found = true
 				var updatedProject v1.StarterProject
 

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -1,8 +1,6 @@
 package testingutil
 
 import (
-	"strings"
-
 	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	devfilepkg "github.com/devfile/api/pkg/devfile"
 )
@@ -79,10 +77,6 @@ func (d TestDevfileData) GetCommands() map[string]v1.Command {
 	commands := make(map[string]v1.Command, len(d.Commands))
 
 	for _, command := range d.Commands {
-		// we convert devfile command id to lowercase so that we can handle
-		// cases efficiently without being error prone
-		// we also convert the odo push commands from build-command and run-command flags
-		command.Id = strings.ToLower(command.Id)
 		commands[command.Id] = command
 	}
 


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?
This PR removes occurances of `strings.ToLower` as this was copied from odo repository. The library should not do any conversion of parsed data whatsoever and stay true to its data. 

Any cleaning or conversion of data can be done in the respective consumer repository

### What issues does this PR fix or reference?


### Is your PR tested? Consider putting some instruction how to test your changes
