### PR TITLE
add back strings.tolower to getcommands and updatecommand

### DIFF
--- a/pkg/devfile/parser/data/v2/commands.go
+++ b/pkg/devfile/parser/data/v2/commands.go
@@ -1,6 +1,8 @@
 package v2
 
 import (
+	"strings"
+
 	v1 "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 )
@@ -11,6 +13,7 @@ func (d *DevfileV2) GetCommands() map[string]v1.Command {
 	commands := make(map[string]v1.Command, len(d.Commands))
 
 	for _, command := range d.Commands {
+		command.Id = strings.ToLower(command.Id)
 		commands[command.Id] = command
 	}
 
@@ -35,8 +38,9 @@ func (d *DevfileV2) AddCommands(commands ...v1.Command) error {
 // UpdateCommand updates the command with the given id
 func (d *DevfileV2) UpdateCommand(command v1.Command) {
 	for i := range d.Commands {
-		if d.Commands[i].Id == command.Id {
+		if strings.ToLower(d.Commands[i].Id) == strings.ToLower(command.Id) {
 			d.Commands[i] = command
+			d.Commands[i].Id = strings.ToLower(d.Commands[i].Id)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?
This PR adds back the `strings.tolower` to getcommands and updatecommand to unblock parser integration in odo
The removal would be fully done in https://github.com/devfile/library/pull/41



### Is your PR tested? Consider putting some instruction how to test your changes
Tested with odo integration tests