### PR TITLE
Upload parent in prep for schema tests

### DIFF
--- a/tests/v2/devfiles/samples/testParent.yaml
+++ b/tests/v2/devfiles/samples/testParent.yaml
@@ -1,0 +1,114 @@
+schemaVersion: "2.0.0"
+commands:
+  - id: testexecparent1
+    exec:
+      commandLine: 'echo "Hello ${GREETING} ${USER}"'
+      component: parserTest-tests
+      group:
+        isDefault: false
+        kind: run
+      hotReloadCapable: false
+      label: "Command Exec run"
+      env:
+        - name: "USER"
+          value: "Test Tester"
+        - name: "GREETING"
+          value: "Hello"
+      workingDir: This Directory
+  - id: testcompositeparent1
+    attributes:
+      test: Composite Test test
+      scope: Api
+    composite:
+      label: Composite Test
+      commands:
+        - runTest1
+        - runTest2
+      parallel: false
+      group:
+        isDefault: true
+        kind: test
+components:
+  - container:
+      args: [ Arg1,Arg2 ]
+      command: [ run1,run2 ]
+      dedicatedPod: true
+      image: "tester"
+      memoryLimit: "128M"
+      mountSources: false
+      endpoints:
+        - name: test-endpoint
+          attributes:
+            test: Apply Test
+            scope: Api
+          exposure: public
+          path: test-path
+          protocol: http
+          secure: false
+          targetPort: 1234
+      volumeMounts:
+        - name: volume
+          path: mount
+      sourceMapping: sourceMapping
+      env:
+        - name: envName
+          value: envValue
+    name: "testcontainerparent1"
+  - name: "testopenshiftparent1"
+    openshift:
+      uri: test-uri
+      endpoints:
+        - name: test-endpoint
+          attributes:
+            test: Apply Test
+            scope: Api
+          exposure: public
+          path: test-path
+          protocol: http
+          secure: false
+          targetPort: 1234
+projects:
+  - name: testparentproject1
+    git:
+      checkoutFrom:
+        remote: test-branch
+      remotes:
+        origin: test-origin
+    clonePath: /Users/test/projects
+    sparseCheckoutDirs: [thisDir, thatDir]
+  - name: testparentproject2
+    github:
+      checkoutFrom:
+        remote: test-branch
+      remotes:
+        origin: test-origin
+    clonePath: /Users/test/projects
+    sparseCheckoutDirs: [thisDir, thatDir]
+  - name: testparentproject3
+    zip:
+      location: git-repo.zip
+    clonePath: /Users/test/projects
+    sparseCheckoutDirs: [thisDir, thatDir]
+starterProjects:
+- name: testparentstarterproject1
+  git:
+    checkoutFrom:
+      remote: test-branch
+    remotes:
+      origin: test-origin
+  description: Test starter project
+  subDir: test-subdir
+- name: testparentstarterproject2
+  github:
+    checkoutFrom:
+      remote: test-branch
+    remotes:
+      origin: test-origin
+  description: Test starter project
+  subDir: test-subdir
+- name: testparentstarterproject3
+  zip:
+    location: git-repo.zip
+  description: Test starter project
+  subDir: test-subdir
+


### PR DESCRIPTION
Tests need to pull a parent/plugin using a uri so just merging the parent which the tests use. Can then add the uri to the tests before creating a pull request for the tests.