### PR TITLE
Support 2.0 and 2.1 schema

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.0.0
+schemaVersion: 2.1.0
 metadata:
   name: nodejs
   version: 1.0.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/library
 go 1.13
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20210111205815-273464363288
+	github.com/devfile/api/v2 v2.0.0-20210121164412-49ba915897f4
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -44,12 +44,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api/v2 v2.0.0-20210111205815-273464363288 h1:3Ea0dVgtCEyWSjobneehLnqIGoK2pS6bWnGnJ1ek24Q=
-github.com/devfile/api/v2 v2.0.0-20210111205815-273464363288/go.mod h1:ujP0i3nip2g/aSOXGEy3A7vTC6EIe1kZf9Cteja6OJg=
 github.com/devfile/api/v2 v2.0.0-20210121164412-49ba915897f4 h1:jDzWFpF/BoyaemoPjAzw5SmlX172JsSsh+Frujm5Ww4=
 github.com/devfile/api/v2 v2.0.0-20210121164412-49ba915897f4/go.mod h1:Cot4snybn3qhIh48oIFi9McocnIx7zY5fFbjfrIpPvg=
-github.com/devfile/api/v2 v2.0.0 h1:pk4d5pFHmWuX6cvlrBK4T+o1r2S/R4r2CCEKE4PiXJ4=
-github.com/devfile/api/v2 v2.0.0/go.mod h1:Cot4snybn3qhIh48oIFi9McocnIx7zY5fFbjfrIpPvg=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/devfile/api/v2 v2.0.0-20210111205815-273464363288 h1:3Ea0dVgtCEyWSjobneehLnqIGoK2pS6bWnGnJ1ek24Q=
 github.com/devfile/api/v2 v2.0.0-20210111205815-273464363288/go.mod h1:ujP0i3nip2g/aSOXGEy3A7vTC6EIe1kZf9Cteja6OJg=
+github.com/devfile/api/v2 v2.0.0-20210121164412-49ba915897f4 h1:jDzWFpF/BoyaemoPjAzw5SmlX172JsSsh+Frujm5Ww4=
+github.com/devfile/api/v2 v2.0.0-20210121164412-49ba915897f4/go.mod h1:Cot4snybn3qhIh48oIFi9McocnIx7zY5fFbjfrIpPvg=
+github.com/devfile/api/v2 v2.0.0 h1:pk4d5pFHmWuX6cvlrBK4T+o1r2S/R4r2CCEKE4PiXJ4=
+github.com/devfile/api/v2 v2.0.0/go.mod h1:Cot4snybn3qhIh48oIFi9McocnIx7zY5fFbjfrIpPvg=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -290,6 +294,7 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 	if len(os.Args) > 1 {
 		if strings.HasPrefix(os.Args[1], "http") {
 			devfile, err = devfilepkg.ParseFromURLAndValidate(os.Args[1])
-		} else{
+		} else {
 			devfile, err = ParseDevfile(os.Args[1])
 		}
 		fmt.Println("parsing devfile from " + os.Args[1])

--- a/main.go
+++ b/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"reflect"
+	"strings"
 
 	devfilepkg "github.com/devfile/library/pkg/devfile"
 	"github.com/devfile/library/pkg/devfile/parser"
@@ -11,7 +13,20 @@ import (
 )
 
 func main() {
-	devfile, err := ParseDevfile("./devfile.yaml")
+	var devfile parser.DevfileObj
+	var err error
+	if len(os.Args) > 1 {
+		if strings.HasPrefix(os.Args[1], "http") {
+			devfile, err = devfilepkg.ParseFromURLAndValidate(os.Args[1])
+		} else{
+			devfile, err = ParseDevfile(os.Args[1])
+		}
+		fmt.Println("parsing devfile from " + os.Args[1])
+
+	} else {
+		devfile, err = ParseDevfile("devfile.yaml")
+		fmt.Println("parsing devfile from " + devfile.Ctx.GetAbsPath())
+	}
 	if err != nil {
 		fmt.Println(err)
 	} else {

--- a/pkg/devfile/parser/data/v2/2.1.0/devfileJsonSchema210.go
+++ b/pkg/devfile/parser/data/v2/2.1.0/devfileJsonSchema210.go
@@ -1,10 +1,10 @@
-package version200
+package version210
 
-// https://raw.githubusercontent.com/devfile/api/2.0.x/schemas/latest/devfile.json
-const JsonSchema200 = `{
+// https://raw.githubusercontent.com/devfile/api/master/schemas/latest/devfile.json
+const JsonSchema210 = `{
   "description": "Devfile describes the structure of a cloud-native workspace and development environment.",
   "type": "object",
-  "title": "Devfile schema - Version 2.0.0",
+  "title": "Devfile schema - Version 2.1.0-alpha",
   "required": [
     "schemaVersion"
   ],
@@ -387,6 +387,12 @@ const JsonSchema200 = `{
                   "type": "string"
                 }
               },
+              "cpuLimit": {
+                "type": "string"
+              },
+              "cpuRequest": {
+                "type": "string"
+              },
               "dedicatedPod": {
                 "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
                 "type": "boolean"
@@ -472,6 +478,9 @@ const JsonSchema200 = `{
                 "type": "string"
               },
               "memoryLimit": {
+                "type": "string"
+              },
+              "memoryRequest": {
                 "type": "string"
               },
               "mountSources": {
@@ -1052,6 +1061,12 @@ const JsonSchema200 = `{
                             "type": "string"
                           }
                         },
+                        "cpuLimit": {
+                          "type": "string"
+                        },
+                        "cpuRequest": {
+                          "type": "string"
+                        },
                         "dedicatedPod": {
                           "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
                           "type": "boolean"
@@ -1133,6 +1148,9 @@ const JsonSchema200 = `{
                           "type": "string"
                         },
                         "memoryLimit": {
+                          "type": "string"
+                        },
+                        "memoryRequest": {
                           "type": "string"
                         },
                         "mountSources": {
@@ -1850,6 +1868,12 @@ const JsonSchema200 = `{
                       "type": "string"
                     }
                   },
+                  "cpuLimit": {
+                    "type": "string"
+                  },
+                  "cpuRequest": {
+                    "type": "string"
+                  },
                   "dedicatedPod": {
                     "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
                     "type": "boolean"
@@ -1931,6 +1955,9 @@ const JsonSchema200 = `{
                     "type": "string"
                   },
                   "memoryLimit": {
+                    "type": "string"
+                  },
+                  "memoryRequest": {
                     "type": "string"
                   },
                   "mountSources": {
@@ -2504,6 +2531,12 @@ const JsonSchema200 = `{
                                 "type": "string"
                               }
                             },
+                            "cpuLimit": {
+                              "type": "string"
+                            },
+                            "cpuRequest": {
+                              "type": "string"
+                            },
                             "dedicatedPod": {
                               "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is 'false'",
                               "type": "boolean"
@@ -2585,6 +2618,9 @@ const JsonSchema200 = `{
                               "type": "string"
                             },
                             "memoryLimit": {
+                              "type": "string"
+                            },
+                            "memoryRequest": {
                               "type": "string"
                             },
                             "mountSources": {

--- a/pkg/devfile/parser/data/versions.go
+++ b/pkg/devfile/parser/data/versions.go
@@ -5,6 +5,7 @@ import (
 
 	v2 "github.com/devfile/library/pkg/devfile/parser/data/v2"
 	v200 "github.com/devfile/library/pkg/devfile/parser/data/v2/2.0.0"
+	v210 "github.com/devfile/library/pkg/devfile/parser/data/v2/2.1.0"
 )
 
 // SupportedApiVersions stores the supported devfile API versions
@@ -13,6 +14,7 @@ type supportedApiVersion string
 // Supported devfile API versions
 const (
 	APIVersion200 supportedApiVersion = "2.0.0"
+	APIVersion210 supportedApiVersion = "2.1.0"
 )
 
 // ------------- Init functions ------------- //
@@ -24,6 +26,7 @@ var apiVersionToDevfileStruct map[supportedApiVersion]reflect.Type
 func init() {
 	apiVersionToDevfileStruct = make(map[supportedApiVersion]reflect.Type)
 	apiVersionToDevfileStruct[APIVersion200] = reflect.TypeOf(v2.DevfileV2{})
+	apiVersionToDevfileStruct[APIVersion210] = reflect.TypeOf(v2.DevfileV2{})
 }
 
 // Map to store mappings between supported devfile API versions and respective devfile JSON schemas
@@ -33,4 +36,5 @@ var devfileApiVersionToJSONSchema map[supportedApiVersion]string
 func init() {
 	devfileApiVersionToJSONSchema = make(map[supportedApiVersion]string)
 	devfileApiVersionToJSONSchema[APIVersion200] = v200.JsonSchema200
+	devfileApiVersionToJSONSchema[APIVersion210] = v210.JsonSchema210
 }


### PR DESCRIPTION
### What does this PR do?
The PR saves a copy of GA version of devfile 2.0 schema, and put latest devfile schema under 2.1.0 folder
This PR adds support for devfile 2.1, and pulls latest api pkg
modifies main.go to accept an arg which can be a http/https URL or a devfile path

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/api/issues/326

### Is your PR tested? Consider putting some instruction how to test your changes
pass the unit tests and api tests