### PR TITLE
relative uri support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/library
 go 1.13
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20210121164412-49ba915897f4
+	github.com/devfile/api/v2 v2.0.0-20210202172954-6424f4139ac7
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api/v2 v2.0.0-20210121164412-49ba915897f4 h1:jDzWFpF/BoyaemoPjAzw5SmlX172JsSsh+Frujm5Ww4=
-github.com/devfile/api/v2 v2.0.0-20210121164412-49ba915897f4/go.mod h1:Cot4snybn3qhIh48oIFi9McocnIx7zY5fFbjfrIpPvg=
+github.com/devfile/api/v2 v2.0.0-20210202172954-6424f4139ac7 h1:bQGUVLEGQtVkvS94K4gQbu57Rk/npcZQmgORmCWYNy8=
+github.com/devfile/api/v2 v2.0.0-20210202172954-6424f4139ac7/go.mod h1:Cot4snybn3qhIh48oIFi9McocnIx7zY5fFbjfrIpPvg=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=

--- a/pkg/devfile/parser/context/context.go
+++ b/pkg/devfile/parser/context/context.go
@@ -1,12 +1,15 @@
 package parser
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/devfile/library/pkg/testingutil/filesystem"
 	"github.com/devfile/library/pkg/util"
 	"k8s.io/klog"
 )
+
+var URIMap = make(map[string]bool)
 
 // DevfileCtx stores context info regarding devfile
 type DevfileCtx struct {
@@ -67,6 +70,10 @@ func (d *DevfileCtx) Populate() (err error) {
 		return err
 	}
 	klog.V(4).Infof("absolute devfile path: '%s'", d.absPath)
+	if _, exist := URIMap[d.absPath]; exist {
+		return fmt.Errorf("URI %v is recursively referenced", d.absPath)
+	}
+	URIMap[d.absPath] = true
 	// Read and save devfile content
 	if err := d.SetDevfileContent(); err != nil {
 		return err
@@ -81,7 +88,10 @@ func (d *DevfileCtx) PopulateFromURL() (err error) {
 	if err != nil {
 		return err
 	}
-
+	if _, exist := URIMap[d.url]; exist {
+		return fmt.Errorf("URI %v is recursively referenced", d.url)
+	}
+	URIMap[d.url] = true
 	// Read and save devfile content
 	if err := d.SetDevfileContent(); err != nil {
 		return err
@@ -101,8 +111,14 @@ func (d *DevfileCtx) Validate() error {
 	return d.ValidateDevfileSchema()
 }
 
+// GetAbsPath func returns current devfile absolute path
 func (d *DevfileCtx) GetAbsPath() string {
 	return d.absPath
+}
+
+// GetURL func returns current devfile absolute URL address
+func (d *DevfileCtx) GetURL() string {
+	return d.url
 }
 
 // SetAbsPath sets absolute file path for devfile

--- a/pkg/devfile/parser/context/context.go
+++ b/pkg/devfile/parser/context/context.go
@@ -70,7 +70,7 @@ func (d *DevfileCtx) Populate() (err error) {
 		return err
 	}
 	klog.V(4).Infof("absolute devfile path: '%s'", d.absPath)
-	if _, exist := URIMap[d.absPath]; exist {
+	if URIMap[d.absPath] {
 		return fmt.Errorf("URI %v is recursively referenced", d.absPath)
 	}
 	URIMap[d.absPath] = true
@@ -88,7 +88,7 @@ func (d *DevfileCtx) PopulateFromURL() (err error) {
 	if err != nil {
 		return err
 	}
-	if _, exist := URIMap[d.url]; exist {
+	if URIMap[d.url] {
 		return fmt.Errorf("URI %v is recursively referenced", d.url)
 	}
 	URIMap[d.url] = true

--- a/pkg/devfile/parser/parse.go
+++ b/pkg/devfile/parser/parse.go
@@ -16,6 +16,7 @@ import (
 
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	apiOverride "github.com/devfile/api/v2/pkg/utils/overriding"
+	"github.com/devfile/api/v2/pkg/validation"
 	"github.com/pkg/errors"
 )
 
@@ -180,6 +181,10 @@ func parseParentAndPlugin(d DevfileObj) (err error) {
 
 func parseFromURI(uri string, curDevfile DevfileObj) (DevfileObj, error) {
 	// validate URI
+	err := validation.ValidateURI(uri)
+	if err != nil {
+		return DevfileObj{}, err
+	}
 
 	// absolute URL address
 	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
@@ -188,7 +193,6 @@ func parseFromURI(uri string, curDevfile DevfileObj) (DevfileObj, error) {
 
 	// relative path on disk
 	if curDevfile.Ctx.GetAbsPath() != "" {
-
 		return Parse(path.Join(path.Dir(curDevfile.Ctx.GetAbsPath()), uri))
 	}
 

--- a/pkg/devfile/parser/parse.go
+++ b/pkg/devfile/parser/parse.go
@@ -19,8 +19,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-
-
 // ParseDevfile func validates the devfile integrity.
 // Creates devfile context and runtime objects
 func parseDevfile(d DevfileObj, flattenedDevfile bool) (DevfileObj, error) {
@@ -180,9 +178,7 @@ func parseParentAndPlugin(d DevfileObj) (err error) {
 	return nil
 }
 
-
-
-func parseFromURI(uri string, curDevfile DevfileObj) (DevfileObj, error){
+func parseFromURI(uri string, curDevfile DevfileObj) (DevfileObj, error) {
 	// validate URI
 
 	// absolute URL address
@@ -190,23 +186,19 @@ func parseFromURI(uri string, curDevfile DevfileObj) (DevfileObj, error){
 		return ParseFromURL(uri)
 	}
 
-	// absolute path on disk
-	if strings.HasPrefix(uri, "file://") {
-		return Parse(strings.TrimPrefix(uri, "file://"))
-	}
-
 	// relative path on disk
-	if curDevfile.Ctx.GetAbsPath() != ""{
-		// parse uri receives a relative path and resolves abspath
-		return Parse(uri)
+	if curDevfile.Ctx.GetAbsPath() != "" {
+
+		return Parse(path.Join(path.Dir(curDevfile.Ctx.GetAbsPath()), uri))
 	}
 
-	if curDevfile.Ctx.GetURL() != ""{
+	if curDevfile.Ctx.GetURL() != "" {
 		u, err := url.Parse(curDevfile.Ctx.GetURL())
-		if err!= nil {
+		if err != nil {
 			return DevfileObj{}, err
 		}
-		u.Path = path.Join(u.Path, uri)
+
+		u.Path = path.Join(path.Dir(u.Path), uri)
 		jointURL := u.String()
 		return ParseFromURL(jointURL)
 	}

--- a/pkg/devfile/parser/parse.go
+++ b/pkg/devfile/parser/parse.go
@@ -119,7 +119,7 @@ func parseParentAndPlugin(d DevfileObj) (err error) {
 			parent := d.Data.GetParent()
 			var parentDevfileObj DevfileObj
 			if d.Data.GetParent().Uri != "" {
-				parentDevfileObj, err = parseFromURI(parent.Uri, d)
+				parentDevfileObj, err = parseFromURI(parent.Uri, d.Ctx)
 				if err != nil {
 					return err
 				}
@@ -150,7 +150,7 @@ func parseParentAndPlugin(d DevfileObj) (err error) {
 			plugin := component.Plugin
 			var pluginDevfileObj DevfileObj
 			if plugin.Uri != "" {
-				pluginDevfileObj, err = parseFromURI(plugin.Uri, d)
+				pluginDevfileObj, err = parseFromURI(plugin.Uri, d.Ctx)
 				if err != nil {
 					return err
 				}
@@ -179,7 +179,7 @@ func parseParentAndPlugin(d DevfileObj) (err error) {
 	return nil
 }
 
-func parseFromURI(uri string, curDevfile DevfileObj) (DevfileObj, error) {
+func parseFromURI(uri string, curDevfileCtx devfileCtx.DevfileCtx) (DevfileObj, error) {
 	// validate URI
 	err := validation.ValidateURI(uri)
 	if err != nil {
@@ -192,19 +192,19 @@ func parseFromURI(uri string, curDevfile DevfileObj) (DevfileObj, error) {
 	}
 
 	// relative path on disk
-	if curDevfile.Ctx.GetAbsPath() != "" {
-		return Parse(path.Join(path.Dir(curDevfile.Ctx.GetAbsPath()), uri))
+	if curDevfileCtx.GetAbsPath() != "" {
+		return Parse(path.Join(path.Dir(curDevfileCtx.GetAbsPath()), uri))
 	}
 
-	if curDevfile.Ctx.GetURL() != "" {
-		u, err := url.Parse(curDevfile.Ctx.GetURL())
+	if curDevfileCtx.GetURL() != "" {
+		u, err := url.Parse(curDevfileCtx.GetURL())
 		if err != nil {
 			return DevfileObj{}, err
 		}
 
 		u.Path = path.Join(path.Dir(u.Path), uri)
-		jointURL := u.String()
-		return ParseFromURL(jointURL)
+		// u.String() is the joint absolute URL path
+		return ParseFromURL(u.String())
 	}
 
 	return DevfileObj{}, fmt.Errorf("fail to parse from uri: %s", uri)

--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -2404,6 +2404,7 @@ func Test_parseFromURI(t *testing.T) {
 	const httpPrefix = "http://"
 	const localRelativeURI = "testTmp/dir/devfile.yaml"
 	const notExistURI = "notexist/devfile.yaml"
+	const invalidURL = "http//invalid.com"
 	uri2 := path.Join(uri1, localRelativeURI)
 
 	localDevfile := DevfileObj{
@@ -2641,6 +2642,28 @@ func Test_parseFromURI(t *testing.T) {
 				},
 			},
 			uri:     notExistURI,
+			wantErr: true,
+		},
+		{
+			name: "case 6: should fail if with invalid URI format",
+			curDevfile: DevfileObj{
+				Ctx: devfileCtx.NewURLDevfileCtx(OutputDevfileYamlPath),
+				Data: &v2.DevfileV2{
+					Devfile: v1.Devfile{
+						DevWorkspaceTemplateSpec: v1.DevWorkspaceTemplateSpec{
+							Parent: &v1.Parent{
+								ImportReference: v1.ImportReference{
+									ImportReferenceUnion: v1.ImportReferenceUnion{
+										Uri: invalidURL,
+									},
+								},
+							},
+							DevWorkspaceTemplateSpecContent: v1.DevWorkspaceTemplateSpecContent{},
+						},
+					},
+				},
+			},
+			uri:     invalidURL,
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
### What does this PR do?
This PR adds relative URI support. 
`parseFromURI` checks the current devfile's abspath/url, and append to get the target uri and parse from that uri
 

### What issues does this PR fix or reference?
https://github.com/devfile/api/issues/309

### Is your PR tested? Consider putting some instruction how to test your changes
added unit test to test for relative uris