### PR TITLE
Revert Test Data for odo

### DIFF
--- a/pkg/devfile/generator/generators_test.go
+++ b/pkg/devfile/generator/generators_test.go
@@ -4,11 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/api/v2/pkg/attributes"
 	"github.com/devfile/library/pkg/devfile/parser"
-	v2 "github.com/devfile/library/pkg/devfile/parser/data/v2"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	"github.com/devfile/library/pkg/testingutil"
 
@@ -27,20 +25,6 @@ func TestGetContainers(t *testing.T) {
 	containerImages := []string{"image1", "image2"}
 	trueMountSources := true
 	falseMountSources := false
-
-	project := v1alpha2.Project{
-		ClonePath: "test-project/",
-		Name:      "project0",
-		ProjectSource: v1.ProjectSource{
-			Git: &v1.GitProjectSource{
-				GitLikeProjectSource: v1.GitLikeProjectSource{
-					Remotes: map[string]string{
-						"origin": "repo",
-					},
-				},
-			},
-		},
-	}
 
 	tests := []struct {
 		name                  string
@@ -184,17 +168,8 @@ func TestGetContainers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			devObj := parser.DevfileObj{
-				Data: &v2.DevfileV2{
-					Devfile: v1.Devfile{
-						DevWorkspaceTemplateSpec: v1.DevWorkspaceTemplateSpec{
-							DevWorkspaceTemplateSpecContent: v1.DevWorkspaceTemplateSpecContent{
-								Components: tt.containerComponents,
-								Projects: []v1alpha2.Project{
-									project,
-								},
-							},
-						},
-					},
+				Data: &testingutil.TestDevfileData{
+					Components: tt.containerComponents,
 				},
 			}
 

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -1,8 +1,244 @@
 package testingutil
 
 import (
+	"fmt"
+	"strings"
+
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	devfilepkg "github.com/devfile/api/v2/pkg/devfile"
+	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 )
+
+// TestDevfileData is a convenience data type used to mock up a devfile configuration
+type TestDevfileData struct {
+	Components        []v1.Component
+	ExecCommands      []v1.ExecCommand
+	CompositeCommands []v1.CompositeCommand
+	Commands          []v1.Command
+	Events            v1.Events
+}
+
+// GetMetadata is a mock function to get metadata from devfile
+func (d TestDevfileData) GetMetadata() devfilepkg.DevfileMetadata {
+	return devfilepkg.DevfileMetadata{}
+}
+
+// SetMetadata sets metadata for the test devfile
+func (d TestDevfileData) SetMetadata(metadata devfilepkg.DevfileMetadata) {}
+
+// GetSchemaVersion gets the schema version for the test devfile
+func (d TestDevfileData) GetSchemaVersion() string { return "testSchema" }
+
+// SetSchemaVersion sets the schema version for the test devfile
+func (d TestDevfileData) SetSchemaVersion(version string) {}
+
+// GetParent is a mock function to get parent from devfile
+func (d TestDevfileData) GetParent() *v1.Parent {
+	return &v1.Parent{}
+}
+
+// SetParent is a mock function to set parent of the test devfile
+func (d TestDevfileData) SetParent(parent *v1.Parent) {}
+
+// GetEvents is a mock function to get events from devfile
+func (d TestDevfileData) GetEvents() v1.Events {
+	return d.Events
+}
+
+// AddEvents is a mock function to add events to the test devfile
+func (d TestDevfileData) AddEvents(events v1.Events) error { return nil }
+
+// UpdateEvents is a mock function to update the events of the test devfile
+func (d TestDevfileData) UpdateEvents(postStart, postStop, preStart, preStop []string) {}
+
+// GetComponents is a mock function to get the components from a devfile
+func (d TestDevfileData) GetComponents(options common.DevfileOptions) ([]v1.Component, error) {
+	if len(options.Filter) == 0 {
+		return d.Components, nil
+	}
+
+	var components []v1.Component
+	for _, comp := range d.Components {
+		filterIn, err := common.FilterDevfileObject(comp.Attributes, options)
+		if err != nil {
+			return nil, err
+		}
+
+		if filterIn {
+			components = append(components, comp)
+		}
+	}
+
+	return components, nil
+}
+
+// AddComponents is a mock function to add components to the test devfile
+func (d TestDevfileData) AddComponents(components []v1.Component) error { return nil }
+
+// UpdateComponent is a mock function to update the component of the test devfile
+func (d TestDevfileData) UpdateComponent(component v1.Component) {}
+
+// DeleteComponent is a mock func that deletes component from the test devfile
+func (d TestDevfileData) DeleteComponent(name string) error { return nil }
+
+// GetProjects is a mock function to get the projects from a test devfile
+func (d TestDevfileData) GetProjects(options common.DevfileOptions) ([]v1.Project, error) {
+	projectName := [...]string{"test-project", "anotherproject"}
+	clonePath := [...]string{"test-project/", "anotherproject/"}
+	sourceLocation := [...]string{"https://github.com/someproject/test-project.git", "https://github.com/another/project.git"}
+
+	project1 := v1.Project{
+		ClonePath: clonePath[0],
+		Name:      projectName[0],
+		ProjectSource: v1.ProjectSource{
+			Git: &v1.GitProjectSource{
+				GitLikeProjectSource: v1.GitLikeProjectSource{
+					Remotes: map[string]string{
+						"origin": sourceLocation[0],
+					},
+				},
+			},
+		},
+	}
+
+	project2 := v1.Project{
+		ClonePath: clonePath[1],
+		Name:      projectName[1],
+		ProjectSource: v1.ProjectSource{
+			Git: &v1.GitProjectSource{
+				GitLikeProjectSource: v1.GitLikeProjectSource{
+					Remotes: map[string]string{
+						"origin": sourceLocation[1],
+					},
+				},
+			},
+		},
+	}
+	return []v1.Project{project1, project2}, nil
+
+}
+
+// AddProjects is a mock function to add projects to the test devfile
+func (d TestDevfileData) AddProjects(projects []v1.Project) error { return nil }
+
+// UpdateProject is a mock function to update a project for the test devfile
+func (d TestDevfileData) UpdateProject(project v1.Project) {}
+
+// DeleteProject is a mock func that deletes project from the test devfile
+func (d TestDevfileData) DeleteProject(name string) error { return nil }
+
+// GetStarterProjects is a mock function to get the starter projects from a test devfile
+func (d TestDevfileData) GetStarterProjects(options common.DevfileOptions) ([]v1.StarterProject, error) {
+	return []v1.StarterProject{}, nil
+}
+
+// AddStarterProjects is a mock func to add the starter projects to the test devfile
+func (d TestDevfileData) AddStarterProjects(projects []v1.StarterProject) error {
+	return nil
+}
+
+// UpdateStarterProject is a mock func to update the starter project for a test devfile
+func (d TestDevfileData) UpdateStarterProject(project v1.StarterProject) {}
+
+// DeleteStarterProject is a mock func that deletes starter project from the test devfile
+func (d TestDevfileData) DeleteStarterProject(name string) error { return nil }
+
+// GetCommands is a mock function to get the commands from a devfile
+func (d TestDevfileData) GetCommands(options common.DevfileOptions) ([]v1.Command, error) {
+
+	var commands []v1.Command
+
+	for _, command := range d.Commands {
+		// we convert devfile command id to lowercase so that we can handle
+		// cases efficiently without being error prone
+		command.Id = strings.ToLower(command.Id)
+		commands = append(commands, command)
+	}
+
+	return commands, nil
+}
+
+// AddCommands is a mock func that adds commands to the test devfile
+func (d *TestDevfileData) AddCommands(commands []v1.Command) error {
+	devfileCommands, err := d.GetCommands(common.DevfileOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, command := range commands {
+		id := command.Id
+		for _, devfileCommand := range devfileCommands {
+			if id == devfileCommand.Id {
+				return fmt.Errorf("command %s already exist in the devfile", id)
+			}
+		}
+
+		d.Commands = append(d.Commands, command)
+	}
+	return nil
+}
+
+// UpdateCommand is a mock func to update the command in a test devfile
+func (d TestDevfileData) UpdateCommand(command v1.Command) {}
+
+// DeleteCommand is a mock func that deletes command from the test devfile
+func (d TestDevfileData) DeleteCommand(id string) error { return nil }
+
+// AddVolumeMounts is a mock func that adds volume mounts to the test component
+func (d TestDevfileData) AddVolumeMounts(componentName string, volumeMounts []v1.VolumeMount) error {
+	return nil
+}
+
+// DeleteVolumeMount is a mock func that deletes volume mount from the test devfile
+func (d TestDevfileData) DeleteVolumeMount(name string) error { return nil }
+
+// GetVolumeMountPath is a mock func that gets the volume mount path of a container
+func (d TestDevfileData) GetVolumeMountPath(mountName, componentName string) (string, error) {
+	return "", nil
+}
+
+// GetDevfileContainerComponents gets the container components from the test devfile
+func (d TestDevfileData) GetDevfileContainerComponents(options common.DevfileOptions) ([]v1.Component, error) {
+	var components []v1.Component
+	devfileComponents, err := d.GetComponents(options)
+	if err != nil {
+		return nil, err
+	}
+	for _, comp := range devfileComponents {
+		if comp.Container != nil {
+			components = append(components, comp)
+		}
+	}
+	return components, nil
+}
+
+// GetDevfileVolumeComponents gets the volume components from the test devfile
+func (d TestDevfileData) GetDevfileVolumeComponents(options common.DevfileOptions) ([]v1.Component, error) {
+	var components []v1.Component
+	devfileComponents, err := d.GetComponents(options)
+	if err != nil {
+		return nil, err
+	}
+	for _, comp := range devfileComponents {
+		if comp.Volume != nil {
+			components = append(components, comp)
+		}
+	}
+	return components, nil
+}
+
+// GetDevfileWorkspace is a mock func to get the DevfileWorkspace in a test devfile
+func (d TestDevfileData) GetDevfileWorkspace() *v1.DevWorkspaceTemplateSpecContent {
+	return &v1.DevWorkspaceTemplateSpecContent{}
+}
+
+// SetDevfileWorkspace is a mock func to set the DevfileWorkspace in a test devfile
+func (d TestDevfileData) SetDevfileWorkspace(content v1.DevWorkspaceTemplateSpecContent) {}
+
+// Validate is a mock validation that always validates without error
+func (d TestDevfileData) Validate() error {
+	return nil
+}
 
 // GetFakeContainerComponent returns a fake container component for testing.
 func GetFakeContainerComponent(name string) v1.Component {


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?
This PR reverts the Test struct and mock funcs as odo is using them. Pls refer to odo PR comment https://github.com/openshift/odo/pull/4465#discussion_r595774173 for discussion

we should discuss and think about the possibility of replacing these with go mock in the future since the interface is in devfile/library and the consequences for the consumers of devfile/library

### What issues does this PR fix or reference?
reverts back part of the changes made by https://github.com/devfile/library/pull/62/

### Is your PR tested? Consider putting some instruction how to test your changes
yes, updated one of the generator tests to use TestDevfileData to ensure all mock func are implemented as previously