### PR TITLE
support .devfile.yaml and parse from a path

### DIFF
--- a/pkg/devfile/parser/context/content.go
+++ b/pkg/devfile/parser/context/content.go
@@ -54,7 +54,7 @@ func (d *DevfileCtx) SetDevfileContent() error {
 	if d.url != "" {
 		data, err = util.DownloadFileInMemory(d.url)
 		if err != nil {
-			return errors.Wrap(err, "error getting parent info from url")
+			return errors.Wrap(err, "error getting devfile info from url")
 		}
 	} else if d.absPath != "" {
 		// Read devfile

--- a/pkg/devfile/parser/context/context.go
+++ b/pkg/devfile/parser/context/context.go
@@ -3,6 +3,10 @@ package parser
 import (
 	"fmt"
 	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
 
 	"github.com/devfile/library/pkg/testingutil/filesystem"
 	"github.com/devfile/library/pkg/util"
@@ -69,7 +73,17 @@ func (d *DevfileCtx) populateDevfile() (err error) {
 
 // Populate fills the DevfileCtx struct with relevant context info
 func (d *DevfileCtx) Populate() (err error) {
-
+	if !strings.HasSuffix(d.relPath, ".yaml"){
+			if _, err := os.Stat(filepath.Join(d.relPath, "devfile.yaml")); os.IsNotExist(err) {
+				if _, err := os.Stat(filepath.Join(d.relPath, ".devfile.yaml")); os.IsNotExist(err) {
+					return fmt.Errorf("the provided path is not a valid yaml filepath, and no devfile.yaml or .devfile.yaml under provided path: %s", d.relPath)
+				} else {
+					d.relPath = filepath.Join(d.relPath, ".devfile.yaml")
+				}
+			} else {
+				d.relPath = filepath.Join(d.relPath, "devfile.yaml")
+			}
+	}
 	if err := d.SetAbsPath(); err != nil {
 		return err
 	}
@@ -90,10 +104,23 @@ func (d *DevfileCtx) Populate() (err error) {
 
 // PopulateFromURL fills the DevfileCtx struct with relevant context info
 func (d *DevfileCtx) PopulateFromURL() (err error) {
-
-	_, err = url.ParseRequestURI(d.url)
+	u, err := url.ParseRequestURI(d.url)
 	if err != nil {
 		return err
+	}
+	if !strings.HasSuffix(d.url, ".yaml"){
+		u.Path = path.Join(u.Path,"devfile.yaml")
+		param := util.HTTPRequestParams{
+			URL: u.String(),
+		}
+		if _, err = util.HTTPGetRequest(param, 0); err != nil {
+			u.Path = path.Join(u.Path, ".devfile.yaml")
+			param.URL = u.String()
+			if _, err = util.HTTPGetRequest(param, 0); err != nil {
+				return fmt.Errorf("the provided url is not a valid yaml filepath, and no devfile.yaml or .devfile.yaml under provided url: %s", d.url)
+			}
+		}
+		d.url = u.String()
 	}
 	if d.uriMap == nil {
 		d.uriMap = make(map[string]bool)

--- a/pkg/devfile/parser/context/context.go
+++ b/pkg/devfile/parser/context/context.go
@@ -76,7 +76,7 @@ func (d *DevfileCtx) Populate() (err error) {
 	if !strings.HasSuffix(d.relPath, ".yaml") {
 		if _, err := os.Stat(filepath.Join(d.relPath, "devfile.yaml")); os.IsNotExist(err) {
 			if _, err := os.Stat(filepath.Join(d.relPath, ".devfile.yaml")); os.IsNotExist(err) {
-				return fmt.Errorf("the provided path is not a valid yaml filepath, and no devfile.yaml or .devfile.yaml under provided path: %s", d.relPath)
+				return fmt.Errorf("the provided path is not a valid yaml filepath, and devfile.yaml or .devfile.yaml not found in the provided path : %s", d.relPath)
 			} else {
 				d.relPath = filepath.Join(d.relPath, ".devfile.yaml")
 			}
@@ -110,14 +110,10 @@ func (d *DevfileCtx) PopulateFromURL() (err error) {
 	}
 	if !strings.HasSuffix(d.url, ".yaml") {
 		u.Path = path.Join(u.Path, "devfile.yaml")
-		param := util.HTTPRequestParams{
-			URL: u.String(),
-		}
-		if _, err = util.HTTPGetRequest(param, 0); err != nil {
-			u.Path = path.Join(u.Path, ".devfile.yaml")
-			param.URL = u.String()
-			if _, err = util.HTTPGetRequest(param, 0); err != nil {
-				return fmt.Errorf("the provided url is not a valid yaml filepath, and no devfile.yaml or .devfile.yaml under provided url: %s", d.url)
+		if _, err = util.DownloadFileInMemory(u.String()); err != nil {
+			u.Path = path.Join(path.Dir(u.Path), ".devfile.yaml")
+			if _, err = util.DownloadFileInMemory(u.String()); err != nil {
+				return fmt.Errorf("the provided url is not a valid yaml filepath, and devfile.yaml or .devfile.yaml not found in the provided path : %s", d.url)
 			}
 		}
 		d.url = u.String()

--- a/pkg/devfile/parser/context/context.go
+++ b/pkg/devfile/parser/context/context.go
@@ -73,16 +73,16 @@ func (d *DevfileCtx) populateDevfile() (err error) {
 
 // Populate fills the DevfileCtx struct with relevant context info
 func (d *DevfileCtx) Populate() (err error) {
-	if !strings.HasSuffix(d.relPath, ".yaml"){
-			if _, err := os.Stat(filepath.Join(d.relPath, "devfile.yaml")); os.IsNotExist(err) {
-				if _, err := os.Stat(filepath.Join(d.relPath, ".devfile.yaml")); os.IsNotExist(err) {
-					return fmt.Errorf("the provided path is not a valid yaml filepath, and no devfile.yaml or .devfile.yaml under provided path: %s", d.relPath)
-				} else {
-					d.relPath = filepath.Join(d.relPath, ".devfile.yaml")
-				}
+	if !strings.HasSuffix(d.relPath, ".yaml") {
+		if _, err := os.Stat(filepath.Join(d.relPath, "devfile.yaml")); os.IsNotExist(err) {
+			if _, err := os.Stat(filepath.Join(d.relPath, ".devfile.yaml")); os.IsNotExist(err) {
+				return fmt.Errorf("the provided path is not a valid yaml filepath, and no devfile.yaml or .devfile.yaml under provided path: %s", d.relPath)
 			} else {
-				d.relPath = filepath.Join(d.relPath, "devfile.yaml")
+				d.relPath = filepath.Join(d.relPath, ".devfile.yaml")
 			}
+		} else {
+			d.relPath = filepath.Join(d.relPath, "devfile.yaml")
+		}
 	}
 	if err := d.SetAbsPath(); err != nil {
 		return err
@@ -108,8 +108,8 @@ func (d *DevfileCtx) PopulateFromURL() (err error) {
 	if err != nil {
 		return err
 	}
-	if !strings.HasSuffix(d.url, ".yaml"){
-		u.Path = path.Join(u.Path,"devfile.yaml")
+	if !strings.HasSuffix(d.url, ".yaml") {
+		u.Path = path.Join(u.Path, "devfile.yaml")
 		param := util.HTTPRequestParams{
 			URL: u.String(),
 		}

--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -2390,7 +2390,7 @@ func Test_parseParentAndPlugin_RecursivelyReference_withMultipleURI(t *testing.T
 	defer testServer3.Close()
 	t.Run("it should error out if URI is recursively referenced with multiple references", func(t *testing.T) {
 		err := parseParentAndPlugin(devFileObj)
-		expectedErr := fmt.Sprintf("URI %v%v is recursively referenced", httpPrefix, uri1)
+		expectedErr := fmt.Sprintf("URI %v%v/devfile.yaml is recursively referenced", httpPrefix, uri1)
 		// Unexpected error
 		if err == nil || !reflect.DeepEqual(expectedErr, err.Error()) {
 			t.Errorf("Test_parseParentAndPlugin_RecursivelyReference_withMultipleURI() unexpected error = %v", err)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -768,7 +768,7 @@ func HTTPGetRequest(request HTTPRequestParams, cacheFor int) ([]byte, error) {
 
 	// We have a non 1xx / 2xx status, return an error
 	if (resp.StatusCode - 300) > 0 {
-		return nil, errors.Errorf("fail to retrive %s, status code: %s", request.URL, http.StatusText(resp.StatusCode))
+		return nil, errors.Errorf("fail to retrive %s, %v: %s", request.URL, resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
 	// Process http response
@@ -1032,7 +1032,7 @@ func DownloadFileInMemory(url string) ([]byte, error) {
 	}
 	// We have a non 1xx / 2xx status, return an error
 	if (resp.StatusCode - 300) > 0 {
-		return nil, errors.Errorf("fail to retrive %s, status code: %s", url, http.StatusText(resp.StatusCode))
+		return nil, errors.Errorf("fail to retrive %s, %v: %s", url, resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 	defer resp.Body.Close()
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1030,6 +1030,10 @@ func DownloadFileInMemory(url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// We have a non 1xx / 2xx status, return an error
+	if (resp.StatusCode - 300) > 0 {
+		return nil, errors.Errorf("fail to retrive %s: %s", url, http.StatusText(resp.StatusCode))
+	}
 	defer resp.Body.Close()
 
 	return ioutil.ReadAll(resp.Body)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -768,7 +768,7 @@ func HTTPGetRequest(request HTTPRequestParams, cacheFor int) ([]byte, error) {
 
 	// We have a non 1xx / 2xx status, return an error
 	if (resp.StatusCode - 300) > 0 {
-		return nil, errors.Errorf("fail to retrive %s: %s", request.URL, http.StatusText(resp.StatusCode))
+		return nil, errors.Errorf("fail to retrive %s, status code: %s", request.URL, http.StatusText(resp.StatusCode))
 	}
 
 	// Process http response
@@ -1032,7 +1032,7 @@ func DownloadFileInMemory(url string) ([]byte, error) {
 	}
 	// We have a non 1xx / 2xx status, return an error
 	if (resp.StatusCode - 300) > 0 {
-		return nil, errors.Errorf("fail to retrive %s: %s", url, http.StatusText(resp.StatusCode))
+		return nil, errors.Errorf("fail to retrive %s, status code: %s", url, http.StatusText(resp.StatusCode))
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?
Supports parse from a path which contains `devfile.yaml` or `.devfile.yaml`
If the path/url does not ends with `.yaml`, than assumes the value is a directory, and will check for `devfile.yaml` or `.devfile.yaml` under that directory
`devfile.yaml` takes priority than `.devfile.yaml`

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/api/issues/61

### Is your PR tested? Consider putting some instruction how to test your changes
manually tested