### PR TITLE
Container can mount same vol at multiple places

### DIFF
--- a/pkg/devfile/parser/data/interface.go
+++ b/pkg/devfile/parser/data/interface.go
@@ -49,7 +49,7 @@ type DevfileData interface {
 	// volume mount related methods
 	AddVolumeMounts(componentName string, volumeMounts []v1.VolumeMount) error
 	DeleteVolumeMount(name string) error
-	GetVolumeMountPath(mountName, componentName string) (string, error)
+	GetVolumeMountPaths(mountName, componentName string) ([]string, error)
 
 	// workspace related methods
 	GetDevfileWorkspace() *v1.DevWorkspaceTemplateSpecContent

--- a/pkg/devfile/parser/data/interface.go
+++ b/pkg/devfile/parser/data/interface.go
@@ -47,9 +47,9 @@ type DevfileData interface {
 	DeleteCommand(id string) error
 
 	// volume mount related methods
-	AddVolumeMounts(componentName string, volumeMounts []v1.VolumeMount) error
+	AddVolumeMounts(containerName string, volumeMounts []v1.VolumeMount) error
 	DeleteVolumeMount(name string) error
-	GetVolumeMountPaths(mountName, componentName string) ([]string, error)
+	GetVolumeMountPaths(mountName, containerName string) ([]string, error)
 
 	// workspace related methods
 	GetDevfileWorkspace() *v1.DevWorkspaceTemplateSpecContent

--- a/pkg/devfile/parser/data/v2/volumes.go
+++ b/pkg/devfile/parser/data/v2/volumes.go
@@ -9,11 +9,11 @@ import (
 )
 
 // AddVolumeMounts adds the volume mounts to the specified container component
-func (d *DevfileV2) AddVolumeMounts(componentName string, volumeMounts []v1.VolumeMount) error {
+func (d *DevfileV2) AddVolumeMounts(containerName string, volumeMounts []v1.VolumeMount) error {
 	var pathErrorContainers []string
 	found := false
 	for _, component := range d.Components {
-		if component.Container != nil && component.Name == componentName {
+		if component.Container != nil && component.Name == containerName {
 			found = true
 			for _, devfileVolumeMount := range component.Container.VolumeMounts {
 				for _, volumeMount := range volumeMounts {
@@ -31,7 +31,7 @@ func (d *DevfileV2) AddVolumeMounts(componentName string, volumeMounts []v1.Volu
 	if !found {
 		return &common.FieldNotFoundError{
 			Field: "container component",
-			Name:  componentName,
+			Name:  containerName,
 		}
 	}
 
@@ -72,12 +72,12 @@ func (d *DevfileV2) DeleteVolumeMount(name string) error {
 
 // GetVolumeMountPaths gets all the mount paths of the specified volume mount from the specified container component.
 // A container can mount at different paths for a given volume.
-func (d *DevfileV2) GetVolumeMountPaths(mountName, componentName string) ([]string, error) {
+func (d *DevfileV2) GetVolumeMountPaths(mountName, containerName string) ([]string, error) {
 	componentFound := false
 	var mountPaths []string
 
 	for _, component := range d.Components {
-		if component.Container != nil && component.Name == componentName {
+		if component.Container != nil && component.Name == containerName {
 			componentFound = true
 			for _, volumeMount := range component.Container.VolumeMounts {
 				if volumeMount.Name == mountName {
@@ -90,12 +90,12 @@ func (d *DevfileV2) GetVolumeMountPaths(mountName, componentName string) ([]stri
 	if !componentFound {
 		return mountPaths, &common.FieldNotFoundError{
 			Field: "container component",
-			Name:  componentName,
+			Name:  containerName,
 		}
 	}
 
 	if len(mountPaths) == 0 {
-		return mountPaths, fmt.Errorf("volume %s not mounted to component %s", mountName, componentName)
+		return mountPaths, fmt.Errorf("volume %s not mounted to component %s", mountName, containerName)
 	}
 
 	return mountPaths, nil

--- a/pkg/devfile/parser/data/v2/volumes.go
+++ b/pkg/devfile/parser/data/v2/volumes.go
@@ -70,27 +70,33 @@ func (d *DevfileV2) DeleteVolumeMount(name string) error {
 	return nil
 }
 
-// GetVolumeMountPath gets the mount path of the specified volume mount from the specified container component
-func (d *DevfileV2) GetVolumeMountPath(mountName, componentName string) (string, error) {
+// GetVolumeMountPaths gets all the mount paths of the specified volume mount from the specified container component.
+// A container can mount at different paths for a given volume.
+func (d *DevfileV2) GetVolumeMountPaths(mountName, componentName string) ([]string, error) {
 	componentFound := false
+	var mountPaths []string
 
 	for _, component := range d.Components {
 		if component.Container != nil && component.Name == componentName {
 			componentFound = true
 			for _, volumeMount := range component.Container.VolumeMounts {
 				if volumeMount.Name == mountName {
-					return volumeMount.Path, nil
+					mountPaths = append(mountPaths, volumeMount.Path)
 				}
 			}
 		}
 	}
 
 	if !componentFound {
-		return "", &common.FieldNotFoundError{
+		return mountPaths, &common.FieldNotFoundError{
 			Field: "container component",
 			Name:  componentName,
 		}
 	}
 
-	return "", fmt.Errorf("volume %s not mounted to component %s", mountName, componentName)
+	if len(mountPaths) == 0 {
+		return mountPaths, fmt.Errorf("volume %s not mounted to component %s", mountName, componentName)
+	}
+
+	return mountPaths, nil
 }


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?
When reviewing PR https://github.com/openshift/odo/pull/4465, noticed that a same volume can be mounted at diff locations.  So it is not right to return the first mount path, we should return an array of all the mount paths for a specified container component

```
components:
  - name: test2
    volume:
        size: 1Gi
  - name: test
    container:
        image: xyz
        volumeMounts:
           - name: test2
             path: /path1
           - name: test2
             path: /path2
  - name: test3
    container:
        image: xyz
        volumeMounts:
           - name: test2
             path: /path1
           - name: test2
             path: /path2
```

### What issues does this PR fix or reference?


### Is your PR tested? Consider putting some instruction how to test your changes
updated tests