### PR TITLE
restricts registryURL format

### DIFF
--- a/pkg/devfile/parser/parse.go
+++ b/pkg/devfile/parser/parse.go
@@ -285,7 +285,7 @@ func parseFromRegistry(parentId, registryURL string, curDevfileCtx devfileCtx.De
 
 func getDevfileFromRegistry(parentId, registryURL string) ([]byte, error) {
 	if !strings.HasPrefix(registryURL, "http://") && !strings.HasPrefix(registryURL, "https://") {
-		registryURL = fmt.Sprintf("http://%s", registryURL)
+		return nil, fmt.Errorf("the provided registryURL: %s is not a valid URL", registryURL)
 	}
 	param := util.HTTPRequestParams{
 		URL: fmt.Sprintf("%s/devfiles/%s", registryURL, parentId),

--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -2978,7 +2978,7 @@ func Test_parseFromRegistry(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name:          "should be able to parse from provided registryUrl without prefix",
+			name:          "should fail if provided registryUrl does not have protocol prefix",
 			curDevfileCtx: devfileCtx.NewDevfileCtx(OutputDevfileYamlPath),
 			wantDevFile:   parentDevfile,
 			registryUrl:   registry,

--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -2466,7 +2466,7 @@ func Test_parseParentFromRegistry(t *testing.T) {
 		DevWorkspaceTemplateSpec: v1.DevWorkspaceTemplateSpec{
 			Parent: &v1.Parent{
 				ImportReference: v1.ImportReference{
-					RegistryUrl: validRegistry,
+					RegistryUrl: "http://" + validRegistry,
 					ImportReferenceUnion: v1.ImportReferenceUnion{
 						Id: "nodejs",
 					},
@@ -2577,7 +2577,7 @@ func Test_parseParentFromRegistry(t *testing.T) {
 	}
 
 	ctxWithRegistry := devfileCtx.NewDevfileCtx(OutputDevfileYamlPath)
-	ctxWithRegistry.SetRegistryURLs([]string{validRegistry})
+	ctxWithRegistry.SetRegistryURLs([]string{"http://" + validRegistry})
 
 	tests := []struct {
 		name                   string
@@ -2908,7 +2908,7 @@ func Test_parseFromRegistry(t *testing.T) {
 	)
 
 	ctxWithRegistry := devfileCtx.NewDevfileCtx(OutputDevfileYamlPath)
-	ctxWithRegistry.SetRegistryURLs([]string{registry})
+	ctxWithRegistry.SetRegistryURLs([]string{"http://" + registry})
 
 	parentDevfile := DevfileObj{
 		Data: &v2.DevfileV2{
@@ -2983,6 +2983,7 @@ func Test_parseFromRegistry(t *testing.T) {
 			wantDevFile:   parentDevfile,
 			registryUrl:   registry,
 			registryId:    registryId,
+			wantErr:       true,
 		},
 		{
 			name:          "should be able to parse from provided registryUrl with prefix",
@@ -3026,7 +3027,7 @@ func Test_parseFromRegistry(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(got.Data, tt.wantDevFile.Data) {
+			if err == nil && !reflect.DeepEqual(got.Data, tt.wantDevFile.Data) {
 				t.Errorf("wanted: %v, got: %v, difference at %v", tt.wantDevFile, got, pretty.Compare(tt.wantDevFile, got))
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?
This PR restricts the `registryURL` format, protocol is expected to be included as part of the `registryURL`

Since the filed is `registryURL`, it is expected to follow the url format. library does not need to help resolve the format, and should not take registry host as the url

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/api/issues/386

### Is your PR tested? Consider putting some instruction how to test your changes
Update unit tests