### PR TITLE
get networking v1 ingress

### DIFF
--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -13,6 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -240,6 +241,19 @@ func GetIngress(ingressParams IngressParams) *extensionsv1.Ingress {
 	ingressSpec := getIngressSpec(ingressParams.IngressSpecParams)
 
 	ingress := &extensionsv1.Ingress{
+		TypeMeta:   ingressParams.TypeMeta,
+		ObjectMeta: ingressParams.ObjectMeta,
+		Spec:       *ingressSpec,
+	}
+
+	return ingress
+}
+
+// GetNetworkingV1Ingress gets a networking v1 ingress
+func GetNetworkingV1Ingress(ingressParams IngressParams) *networkingv1.Ingress {
+	ingressSpec := getNetworkingV1IngressSpec(ingressParams.IngressSpecParams)
+
+	ingress := &networkingv1.Ingress{
 		TypeMeta:   ingressParams.TypeMeta,
 		ObjectMeta: ingressParams.ObjectMeta,
 		Spec:       *ingressSpec,

--- a/pkg/devfile/generator/utils_test.go
+++ b/pkg/devfile/generator/utils_test.go
@@ -1158,7 +1158,7 @@ func TestGetPortExposure(t *testing.T) {
 
 }
 
-func TestGenerateIngressSpec(t *testing.T) {
+func TestGetIngressSpec(t *testing.T) {
 
 	tests := []struct {
 		name      string
@@ -1192,6 +1192,50 @@ func TestGenerateIngressSpec(t *testing.T) {
 
 			if ingressSpec.Rules[0].HTTP.Paths[0].Backend.ServiceName != tt.parameter.ServiceName {
 				t.Errorf("expected %s, actual %s", tt.parameter.ServiceName, ingressSpec.Rules[0].HTTP.Paths[0].Backend.ServiceName)
+			}
+
+			if ingressSpec.TLS[0].SecretName != tt.parameter.TLSSecretName {
+				t.Errorf("expected %s, actual %s", tt.parameter.TLSSecretName, ingressSpec.TLS[0].SecretName)
+			}
+
+		})
+	}
+}
+
+func TestGetNetworkingV1IngressSpec(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		parameter IngressSpecParams
+	}{
+		{
+			name: "1",
+			parameter: IngressSpecParams{
+				ServiceName:   "service1",
+				IngressDomain: "test.1.2.3.4.nip.io",
+				PortNumber: intstr.IntOrString{
+					IntVal: 8080,
+				},
+				TLSSecretName: "testTLSSecret",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ingressSpec := getNetworkingV1IngressSpec(tt.parameter)
+
+			if ingressSpec.Rules[0].Host != tt.parameter.IngressDomain {
+				t.Errorf("expected %s, actual %s", tt.parameter.IngressDomain, ingressSpec.Rules[0].Host)
+			}
+
+			if ingressSpec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number != tt.parameter.PortNumber.IntVal {
+				t.Errorf("expected %v, actual %v", tt.parameter.PortNumber, ingressSpec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
+			}
+
+			if ingressSpec.Rules[0].HTTP.Paths[0].Backend.Service.Name != tt.parameter.ServiceName {
+				t.Errorf("expected %s, actual %s", tt.parameter.ServiceName, ingressSpec.Rules[0].HTTP.Paths[0].Backend.Service.Name)
 			}
 
 			if ingressSpec.TLS[0].SecretName != tt.parameter.TLSSecretName {


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?
This PR introduced a new function to get networking.k8s.io/v1 ingress, since v1beta1 ingress is no longer supported in future versions of k8s api

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/api/issues/504

### Is your PR tested? Consider putting some instruction how to test your changes
Added new unit test