### PR TITLE
Adding required field to networkingv1 ingress generator

### DIFF
--- a/pkg/devfile/generator/utils.go
+++ b/pkg/devfile/generator/utils.go
@@ -339,6 +339,7 @@ func getIngressSpec(ingressSpecParams IngressSpecParams) *extensionsv1.IngressSp
 // getNetworkingV1IngressSpec gets a networking v1 ingress spec
 func getNetworkingV1IngressSpec(ingressSpecParams IngressSpecParams) *networkingv1.IngressSpec {
 	path := "/"
+	pathTypeImplementationSpecific := networkingv1.PathTypeImplementationSpecific
 	if ingressSpecParams.Path != "" {
 		path = ingressSpecParams.Path
 	}
@@ -359,6 +360,8 @@ func getNetworkingV1IngressSpec(ingressSpecParams IngressSpecParams) *networking
 										},
 									},
 								},
+								//Field is required to be set based on attempt to create the ingress
+								PathType: &pathTypeImplementationSpecific,
 							},
 						},
 					},


### PR DESCRIPTION
 - attempting to create ingress without `PathType` specified
results in error

Signed-off-by: Mohammed Zeeshan Ahmed <mohammed.zee1000@gmail.com>

### What does this PR do?
[see title]

### What issues does this PR fix or reference?
No i found this issue while attempting to move odo url creation to use networking v1 ingresses

### Is your PR tested? Consider putting some instructions how to test your changes
Ingresses created by this should be apply on newer kubernetes cluster without error
