### PR TITLE
filter out init containers in GetContainers()

### DIFF
--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -62,9 +62,10 @@ func GetContainers(devfileObj parser.DevfileObj, options common.DevfileOptions) 
 		return nil, err
 	}
 
-	// filter out init containers
+	// filter out containers for preStart and postStop events
 	preStartEvents := devfileObj.Data.GetEvents().PreStart
-	if len(preStartEvents) > 0 {
+	postStopEvents := devfileObj.Data.GetEvents().PostStop
+	if len(preStartEvents) > 0 || len(postStopEvents) > 0 {
 		var eventCommands []string
 		commands, err := devfileObj.Data.GetCommands(common.DevfileOptions{})
 		if err != nil {
@@ -74,6 +75,11 @@ func GetContainers(devfileObj parser.DevfileObj, options common.DevfileOptions) 
 		commandsMap := common.GetCommandsMap(commands)
 
 		for _, event := range preStartEvents {
+			eventSubCommands := common.GetCommandsFromEvent(commandsMap, event)
+			eventCommands = append(eventCommands, eventSubCommands...)
+		}
+
+		for _, event := range postStopEvents {
 			eventSubCommands := common.GetCommandsFromEvent(commandsMap, event)
 			eventCommands = append(eventCommands, eventSubCommands...)
 		}

--- a/pkg/devfile/generator/generators_test.go
+++ b/pkg/devfile/generator/generators_test.go
@@ -218,7 +218,7 @@ func TestGetContainers(t *testing.T) {
 			},
 		},
 		{
-			name: "should not return init container",
+			name: "should not return containers for preStart and postStop events",
 			eventCommands: []string{
 				"apply1",
 			},
@@ -280,12 +280,13 @@ func TestGetContainers(t *testing.T) {
 			// to set up the prestartevent and apply command for init container
 			mockGetCommands := mockDevfileData.EXPECT().GetCommands(common.DevfileOptions{})
 			mockGetCommands.Return(applyCommands, nil).AnyTimes()
-			preStartEvents := v1.Events{
+			events := v1.Events{
 				DevWorkspaceEvents: v1.DevWorkspaceEvents{
 					PreStart: tt.eventCommands,
+					PostStop: tt.eventCommands,
 				},
 			}
-			mockDevfileData.EXPECT().GetEvents().Return(preStartEvents).AnyTimes()
+			mockDevfileData.EXPECT().GetEvents().Return(events).AnyTimes()
 
 			devObj := parser.DevfileObj{
 				Data: mockDevfileData,

--- a/pkg/devfile/generator/utils_test.go
+++ b/pkg/devfile/generator/utils_test.go
@@ -774,7 +774,7 @@ func TestGetServiceSpec(t *testing.T) {
 				mockGetComponents.Return(tt.filteredComponents, nil).AnyTimes()
 			}
 			mockDevfileData.EXPECT().GetProjects(common.DevfileOptions{}).Return(nil, nil).AnyTimes()
-
+			mockDevfileData.EXPECT().GetEvents().Return(v1.Events{}).AnyTimes()
 			devObj := parser.DevfileObj{
 				Data: mockDevfileData,
 			}


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR filters out initContainers in `GetContainers()`

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
Fixes https://github.com/devfile/api/issues/532

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
call `GetContainers` against a devfile with init container, the output is expected to return all containers other than init containers