### PR TITLE
new fields `autobuild` and `deploybydefault` for image components and kubernetes/openshift components

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/library
 go 1.15
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20211118170330-959f3c8007c3
+	github.com/devfile/api/v2 v2.0.0-20211220170551-ef9f515cc912
 	github.com/fatih/color v1.7.0
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/mock v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/library
 go 1.15
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20211220170551-ef9f515cc912
+	github.com/devfile/api/v2 v2.0.0-20211221202911-64979f3d994e
 	github.com/fatih/color v1.7.0
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/mock v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/library
 go 1.15
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20211221202911-64979f3d994e
+	github.com/devfile/api/v2 v2.0.0-20220105201057-dd1d65d4d91f
 	github.com/fatih/color v1.7.0
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/mock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api/v2 v2.0.0-20211221202911-64979f3d994e h1:+wtI5Pq9i58h1xUtQZxFV0Um1Y3l3euck6nhdXO6zik=
-github.com/devfile/api/v2 v2.0.0-20211221202911-64979f3d994e/go.mod h1:d99eTN6QxgzihOOFyOZA+VpUyD4Q1pYRYHZ/ci9J96Q=
+github.com/devfile/api/v2 v2.0.0-20220105201057-dd1d65d4d91f h1:Mdj4fXcQ0hEd7iMsqwydqrW0JfxepoPjzwxrshtvqYY=
+github.com/devfile/api/v2 v2.0.0-20220105201057-dd1d65d4d91f/go.mod h1:d99eTN6QxgzihOOFyOZA+VpUyD4Q1pYRYHZ/ci9J96Q=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api/v2 v2.0.0-20211220170551-ef9f515cc912 h1:jduGMsa/0iVZUpEpGI1uY4NNShRa39buaDTx45aiEQ4=
-github.com/devfile/api/v2 v2.0.0-20211220170551-ef9f515cc912/go.mod h1:d99eTN6QxgzihOOFyOZA+VpUyD4Q1pYRYHZ/ci9J96Q=
+github.com/devfile/api/v2 v2.0.0-20211221202911-64979f3d994e h1:+wtI5Pq9i58h1xUtQZxFV0Um1Y3l3euck6nhdXO6zik=
+github.com/devfile/api/v2 v2.0.0-20211221202911-64979f3d994e/go.mod h1:d99eTN6QxgzihOOFyOZA+VpUyD4Q1pYRYHZ/ci9J96Q=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api/v2 v2.0.0-20211118170330-959f3c8007c3 h1:G7TIrgpGx5lcZ3X7bpQeVCeeeO7tv6SAzPPvB9ThHXE=
-github.com/devfile/api/v2 v2.0.0-20211118170330-959f3c8007c3/go.mod h1:d99eTN6QxgzihOOFyOZA+VpUyD4Q1pYRYHZ/ci9J96Q=
+github.com/devfile/api/v2 v2.0.0-20211220170551-ef9f515cc912 h1:jduGMsa/0iVZUpEpGI1uY4NNShRa39buaDTx45aiEQ4=
+github.com/devfile/api/v2 v2.0.0-20211220170551-ef9f515cc912/go.mod h1:d99eTN6QxgzihOOFyOZA+VpUyD4Q1pYRYHZ/ci9J96Q=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/pkg/devfile/parser/data/v2/2.2.0/devfileJsonSchema220.go
+++ b/pkg/devfile/parser/data/v2/2.2.0/devfileJsonSchema220.go
@@ -458,7 +458,7 @@ const JsonSchema220 = `{
             ],
             "properties": {
               "autoBuild": {
-                "description": "Defines if the image should be built during startup Default is false",
+                "description": "Defines if the image should be built during startup.\n\nDefault value is 'false'",
                 "type": "boolean"
               },
               "dockerfile": {
@@ -582,7 +582,7 @@ const JsonSchema220 = `{
             ],
             "properties": {
               "deployByDefault": {
-                "description": "Defines if the component should be deployed during startup Default is false",
+                "description": "Defines if the component should be deployed during startup.\n\nDefault value is 'false'",
                 "type": "boolean"
               },
               "endpoints": {
@@ -683,7 +683,7 @@ const JsonSchema220 = `{
             ],
             "properties": {
               "deployByDefault": {
-                "description": "Defines if the component should be deployed during startup Default is false",
+                "description": "Defines if the component should be deployed during startup.\n\nDefault value is 'false'",
                 "type": "boolean"
               },
               "endpoints": {
@@ -1341,7 +1341,7 @@ const JsonSchema220 = `{
                 ],
                 "properties": {
                   "autoBuild": {
-                    "description": "Defines if the image should be built during startup Default is false",
+                    "description": "Defines if the image should be built during startup.\n\nDefault value is 'false'",
                     "type": "boolean"
                   },
                   "dockerfile": {
@@ -1459,7 +1459,7 @@ const JsonSchema220 = `{
                 ],
                 "properties": {
                   "deployByDefault": {
-                    "description": "Defines if the component should be deployed during startup Default is false",
+                    "description": "Defines if the component should be deployed during startup.\n\nDefault value is 'false'",
                     "type": "boolean"
                   },
                   "endpoints": {
@@ -1557,7 +1557,7 @@ const JsonSchema220 = `{
                 ],
                 "properties": {
                   "deployByDefault": {
-                    "description": "Defines if the component should be deployed during startup Default is false",
+                    "description": "Defines if the component should be deployed during startup.\n\nDefault value is 'false'",
                     "type": "boolean"
                   },
                   "endpoints": {

--- a/pkg/devfile/parser/data/v2/2.2.0/devfileJsonSchema220.go
+++ b/pkg/devfile/parser/data/v2/2.2.0/devfileJsonSchema220.go
@@ -41,7 +41,7 @@ const JsonSchema220 = `{
         ],
         "properties": {
           "apply": {
-            "description": "Command that consists in applying a given component definition, typically bound to a devworkspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at devworkspace start by default.",
+            "description": "Command that consists in applying a given component definition, typically bound to a devworkspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless 'deployByDefault' for that component is set to false.",
             "type": "object",
             "required": [
               "component"
@@ -457,6 +457,10 @@ const JsonSchema220 = `{
               }
             ],
             "properties": {
+              "autoBuild": {
+                "description": "Defines if the image should be built during startup Default is false",
+                "type": "boolean"
+              },
               "dockerfile": {
                 "description": "Allows specifying dockerfile type build",
                 "type": "object",
@@ -577,6 +581,10 @@ const JsonSchema220 = `{
               }
             ],
             "properties": {
+              "deployByDefault": {
+                "description": "Defines if the component should be deployed during startup Default is false",
+                "type": "boolean"
+              },
               "endpoints": {
                 "type": "array",
                 "items": {
@@ -674,6 +682,10 @@ const JsonSchema220 = `{
               }
             ],
             "properties": {
+              "deployByDefault": {
+                "description": "Defines if the component should be deployed during startup Default is false",
+                "type": "boolean"
+              },
               "endpoints": {
                 "type": "array",
                 "items": {
@@ -935,7 +947,7 @@ const JsonSchema220 = `{
             ],
             "properties": {
               "apply": {
-                "description": "Command that consists in applying a given component definition, typically bound to a devworkspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at devworkspace start by default.",
+                "description": "Command that consists in applying a given component definition, typically bound to a devworkspace event.\n\nFor example, when an 'apply' command is bound to a 'preStart' event, and references a 'container' component, it will start the container as a K8S initContainer in the devworkspace POD, unless the component has its 'dedicatedPod' field set to 'true'.\n\nWhen no 'apply' command exist for a given component, it is assumed the component will be applied at devworkspace start by default, unless 'deployByDefault' for that component is set to false.",
                 "type": "object",
                 "properties": {
                   "component": {
@@ -1320,9 +1332,18 @@ const JsonSchema220 = `{
                     "required": [
                       "dockerfile"
                     ]
+                  },
+                  {
+                    "required": [
+                      "autoBuild"
+                    ]
                   }
                 ],
                 "properties": {
+                  "autoBuild": {
+                    "description": "Defines if the image should be built during startup Default is false",
+                    "type": "boolean"
+                  },
                   "dockerfile": {
                     "description": "Allows specifying dockerfile type build",
                     "type": "object",
@@ -1437,6 +1458,10 @@ const JsonSchema220 = `{
                   }
                 ],
                 "properties": {
+                  "deployByDefault": {
+                    "description": "Defines if the component should be deployed during startup Default is false",
+                    "type": "boolean"
+                  },
                   "endpoints": {
                     "type": "array",
                     "items": {
@@ -1531,6 +1556,10 @@ const JsonSchema220 = `{
                   }
                 ],
                 "properties": {
+                  "deployByDefault": {
+                    "description": "Defines if the component should be deployed during startup Default is false",
+                    "type": "boolean"
+                  },
                   "endpoints": {
                     "type": "array",
                     "items": {

--- a/pkg/devfile/parser/parse.go
+++ b/pkg/devfile/parser/parse.go
@@ -549,10 +549,16 @@ func setDefaults(d DevfileObj) (err error) {
 
 		} else if component.Kubernetes != nil {
 			endpoints = component.Kubernetes.Endpoints
-
+			if devfileVersion != string(data.APISchemaVersion200) && devfileVersion != string(data.APISchemaVersion210) {
+				val := component.Kubernetes.GetDeployByDefault()
+				component.Kubernetes.DeployByDefault = &val
+			}
 		} else if component.Openshift != nil {
-
 			endpoints = component.Openshift.Endpoints
+			if devfileVersion != string(data.APISchemaVersion200) && devfileVersion != string(data.APISchemaVersion210) {
+				val := component.Openshift.GetDeployByDefault()
+				component.Openshift.DeployByDefault = &val
+			}
 
 		} else if component.Volume != nil && devfileVersion != string(data.APISchemaVersion200) {
 			volume := component.Volume
@@ -565,6 +571,8 @@ func setDefaults(d DevfileObj) (err error) {
 				val := dockerImage.GetRootRequired()
 				dockerImage.RootRequired = &val
 			}
+			val := component.Image.GetAutoBuild()
+			component.Image.AutoBuild = &val
 		}
 
 		if endpoints != nil {

--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -160,7 +160,7 @@ func Test_parseParentAndPluginFromURI(t *testing.T) {
 									},
 								},
 							},
-							testingutil.GetDockerImageTestComponent(divRRTrue, nil),
+							testingutil.GetDockerImageTestComponent(divRRTrue, nil, nil),
 						},
 						Events: &v1.Events{
 							DevWorkspaceEvents: v1.DevWorkspaceEvents{
@@ -498,7 +498,7 @@ func Test_parseParentAndPluginFromURI(t *testing.T) {
 											},
 										},
 									},
-									testingutil.GetDockerImageTestComponent(divRRFalse, parentOverridesFromMainDevfile),
+									testingutil.GetDockerImageTestComponent(divRRFalse, nil, parentOverridesFromMainDevfile),
 									{
 										Name: "runtime",
 										ComponentUnion: v1.ComponentUnion{
@@ -736,7 +736,7 @@ func Test_parseParentAndPluginFromURI(t *testing.T) {
 										},
 									},
 									//no overrides so expected values are the same as the parent
-									testingutil.GetDockerImageTestComponent(divRRTrue, importFromUri1),
+									testingutil.GetDockerImageTestComponent(divRRTrue, nil, importFromUri1),
 									{
 										Name: "runtime",
 										ComponentUnion: v1.ComponentUnion{
@@ -1462,7 +1462,7 @@ func Test_parseParentAndPluginFromURI(t *testing.T) {
 											},
 										},
 									},
-									testingutil.GetDockerImageTestComponent(divRRFalse, nil),
+									testingutil.GetDockerImageTestComponent(divRRFalse, nil, nil),
 								},
 								Events: &v1.Events{
 									DevWorkspaceEvents: v1.DevWorkspaceEvents{
@@ -1600,7 +1600,7 @@ func Test_parseParentAndPluginFromURI(t *testing.T) {
 											},
 										},
 									},
-									testingutil.GetDockerImageTestComponent(divRRTrue, pluginOverridesFromMainDevfile),
+									testingutil.GetDockerImageTestComponent(divRRTrue, nil, pluginOverridesFromMainDevfile),
 									{
 										Name: "runtime",
 										ComponentUnion: v1.ComponentUnion{
@@ -3107,7 +3107,7 @@ func Test_parseParentFromRegistry(t *testing.T) {
 									},
 								},
 							},
-							testingutil.GetDockerImageTestComponent(defaultDiv, nil),
+							testingutil.GetDockerImageTestComponent(defaultDiv, nil, nil),
 						},
 					},
 				},
@@ -3249,7 +3249,7 @@ func Test_parseParentFromRegistry(t *testing.T) {
 							},
 						},
 					},
-					testingutil.GetDockerImageTestComponent(div, parentOverridesFromMainDevfile),
+					testingutil.GetDockerImageTestComponent(div, nil, parentOverridesFromMainDevfile),
 					{
 						Name: "runtime2",
 						ComponentUnion: v1.ComponentUnion{
@@ -3389,7 +3389,7 @@ func Test_parseParentFromRegistry(t *testing.T) {
 											},
 										},
 									},
-									testingutil.GetDockerImageTestComponent(defaultDiv, importFromRegistry),
+									testingutil.GetDockerImageTestComponent(defaultDiv, nil, importFromRegistry),
 									{
 										Name: "runtime2",
 										ComponentUnion: v1.ComponentUnion{
@@ -3503,7 +3503,7 @@ func Test_parseParentFromKubeCRD(t *testing.T) {
 						},
 					},
 				},
-				testingutil.GetDockerImageTestComponent(defaultDiv, nil),
+				testingutil.GetDockerImageTestComponent(defaultDiv, nil, nil),
 			},
 		},
 	}
@@ -3522,7 +3522,7 @@ func Test_parseParentFromKubeCRD(t *testing.T) {
 						},
 					},
 				},
-				testingutil.GetDockerImageTestComponent(defaultDiv, nil),
+				testingutil.GetDockerImageTestComponent(defaultDiv, nil, nil),
 			},
 		},
 	}
@@ -3626,7 +3626,7 @@ func Test_parseParentFromKubeCRD(t *testing.T) {
 											},
 										},
 									},
-									testingutil.GetDockerImageTestComponent(div, parentOverridesFromMainDevfile),
+									testingutil.GetDockerImageTestComponent(div, nil, parentOverridesFromMainDevfile),
 									{
 										Name: "runtime",
 										ComponentUnion: v1.ComponentUnion{
@@ -3719,7 +3719,7 @@ func Test_parseParentFromKubeCRD(t *testing.T) {
 											},
 										},
 									},
-									testingutil.GetDockerImageTestComponent(defaultDiv, importFromKubeCRD),
+									testingutil.GetDockerImageTestComponent(defaultDiv, nil, importFromKubeCRD),
 									{
 										Name: "runtime",
 										ComponentUnion: v1.ComponentUnion{
@@ -4490,7 +4490,7 @@ func getUnsetBooleanDevfileTestData(apiVersion string) (devfileData data.Devfile
 	}
 
 	if apiVersion != string(data.APISchemaVersion200) && apiVersion != string(data.APISchemaVersion210) {
-		comp := []v1.Component{testingutil.GetDockerImageTestComponent(testingutil.DockerImageValues{}, nil)}
+		comp := []v1.Component{testingutil.GetDockerImageTestComponent(testingutil.DockerImageValues{}, nil, nil)}
 		err = devfileData.AddComponents(comp)
 	}
 
@@ -4510,12 +4510,14 @@ func getBooleanDevfileTestData(apiVersion string, setDefault bool) (devfileData 
 		isDefault        *bool
 		rootRequired     *bool
 		ephemeral        *bool
+		autoBuild        *bool
+		deployByDefaul   *bool
 	}
 
 	//default values according to spec
-	defaultBools := boolValues{&isFalse, &isFalse, &isFalse, &isFalse, &isTrue, &isFalse, &isFalse, &isFalse}
+	defaultBools := boolValues{&isFalse, &isFalse, &isFalse, &isFalse, &isTrue, &isFalse, &isFalse, &isFalse, &isFalse, &isFalse}
 	//set values will be a mix of default and inverse values
-	setBools := boolValues{&isTrue, &isTrue, &isFalse, &isTrue, &isFalse, &isFalse, &isTrue, &isFalse}
+	setBools := boolValues{&isTrue, &isTrue, &isFalse, &isTrue, &isFalse, &isFalse, &isTrue, &isFalse, &isTrue, &isFalse}
 
 	var values boolValues
 
@@ -4644,8 +4646,14 @@ func getBooleanDevfileTestData(apiVersion string, setDefault bool) (devfileData 
 	}
 
 	if apiVersion != string(data.APISchemaVersion200) && apiVersion != string(data.APISchemaVersion210) {
-		comp := []v1.Component{testingutil.GetDockerImageTestComponent(testingutil.DockerImageValues{RootRequired: values.rootRequired}, nil)}
+		comp := []v1.Component{testingutil.GetDockerImageTestComponent(testingutil.DockerImageValues{RootRequired: values.rootRequired}, values.autoBuild, nil)}
 		err = devfileData.AddComponents(comp)
+
+		openshiftComponent, _ := devfileData.GetComponents(common.DevfileOptions{ComponentOptions: common.ComponentOptions{
+			ComponentType: v1.OpenshiftComponentType,
+		}})
+		openshiftComponent[0].Openshift.DeployByDefault = values.deployByDefaul
+
 	}
 
 	return devfileData, err

--- a/pkg/testingutil/devfile.go
+++ b/pkg/testingutil/devfile.go
@@ -126,7 +126,7 @@ type DockerImageValues struct {
 
 //GetDockerImageTestComponent returns a docker image component that is used for testing.
 //The parameters allow customization of the content.  If they are set to nil, then the properties will not be set
-func GetDockerImageTestComponent(div DockerImageValues, attr attributes.Attributes) v1.Component {
+func GetDockerImageTestComponent(div DockerImageValues, autobuild *bool, attr attributes.Attributes) v1.Component {
 	comp := v1.Component{
 		Name: "image",
 		ComponentUnion: v1.ComponentUnion{
@@ -134,6 +134,7 @@ func GetDockerImageTestComponent(div DockerImageValues, attr attributes.Attribut
 				Image: v1.Image{
 					ImageName: div.ImageName,
 					ImageUnion: v1.ImageUnion{
+						AutoBuild: autobuild,
 						Dockerfile: &v1.DockerfileImage{
 							DockerfileSrc: v1.DockerfileSrc{
 								Uri: div.Uri,


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
pull latest devfile/api pkg and schema which contains the new field `autobuild` and `deploybydefault` for image components and kubernetes/openshift components, respectively. 

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
Fixes https://github.com/devfile/api/issues/693

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
