### PR TITLE
use endpoint name as container port name and service port name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/library
 go 1.15
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20220105201057-dd1d65d4d91f
+	github.com/devfile/api/v2 v2.0.0-20220117162434-6e6e6a8bc14c
 	github.com/fatih/color v1.7.0
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/mock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api/v2 v2.0.0-20220105201057-dd1d65d4d91f h1:Mdj4fXcQ0hEd7iMsqwydqrW0JfxepoPjzwxrshtvqYY=
-github.com/devfile/api/v2 v2.0.0-20220105201057-dd1d65d4d91f/go.mod h1:d99eTN6QxgzihOOFyOZA+VpUyD4Q1pYRYHZ/ci9J96Q=
+github.com/devfile/api/v2 v2.0.0-20220117162434-6e6e6a8bc14c h1:sjghKUov/WT71dBreHYQcTgQctxHT/p4uAhUFdGQfSU=
+github.com/devfile/api/v2 v2.0.0-20220117162434-6e6e6a8bc14c/go.mod h1:d99eTN6QxgzihOOFyOZA+VpUyD4Q1pYRYHZ/ci9J96Q=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/pkg/devfile/generator/generators_test.go
+++ b/pkg/devfile/generator/generators_test.go
@@ -911,7 +911,7 @@ func TestGetService(t *testing.T) {
 				Spec: corev1.ServiceSpec{
 					Ports: []corev1.ServicePort{
 						{
-							Name:       "port-8080",
+							Name:       "http-8080",
 							Port:       8080,
 							TargetPort: intstr.FromInt(8080),
 						},
@@ -949,7 +949,7 @@ func TestGetService(t *testing.T) {
 				Spec: corev1.ServiceSpec{
 					Ports: []corev1.ServicePort{
 						{
-							Name:       "port-8080",
+							Name:       "http-8080",
 							Port:       8080,
 							TargetPort: intstr.FromInt(8080),
 						},

--- a/pkg/devfile/generator/utils.go
+++ b/pkg/devfile/generator/utils.go
@@ -46,7 +46,12 @@ func convertPorts(endpoints []v1.Endpoint) []corev1.ContainerPort {
 		} else {
 			portProtocol = corev1.ProtocolTCP
 		}
-		name := fmt.Sprintf("%d-%s", portNumber, strings.ToLower(string(portProtocol)))
+		name := endpoint.Name
+		if len(name) > 15 {
+			// to be compatible with endpoint longer than 15 chars
+			name = fmt.Sprintf("port-%v", portNumber)
+		}
+
 		if _, exist := portMap[name]; !exist {
 			portMap[name] = true
 			containerPorts = append(containerPorts, corev1.ContainerPort{
@@ -268,7 +273,6 @@ func getServiceSpec(devfileObj parser.DevfileObj, selectorLabels map[string]stri
 			}
 			// if Exposure == none, should not create a service for that port
 			if !portExist && portExposureMap[int(port.ContainerPort)] != v1.NoneEndpointExposure {
-				port.Name = fmt.Sprintf("port-%v", port.ContainerPort)
 				containerPorts = append(containerPorts, port)
 			}
 		}

--- a/pkg/devfile/parser/data/v2/2.2.0/devfileJsonSchema220.go
+++ b/pkg/devfile/parser/data/v2/2.2.0/devfileJsonSchema220.go
@@ -347,7 +347,7 @@ const JsonSchema220 = `{
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
+                      "maxLength": 15,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -372,6 +372,7 @@ const JsonSchema220 = `{
                       "type": "boolean"
                     },
                     "targetPort": {
+                      "description": "The port number should be unique.",
                       "type": "integer"
                     }
                   },
@@ -618,7 +619,7 @@ const JsonSchema220 = `{
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
+                      "maxLength": 15,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -643,6 +644,7 @@ const JsonSchema220 = `{
                       "type": "boolean"
                     },
                     "targetPort": {
+                      "description": "The port number should be unique.",
                       "type": "integer"
                     }
                   },
@@ -719,7 +721,7 @@ const JsonSchema220 = `{
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
+                      "maxLength": 15,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -744,6 +746,7 @@ const JsonSchema220 = `{
                       "type": "boolean"
                     },
                     "targetPort": {
+                      "description": "The port number should be unique.",
                       "type": "integer"
                     }
                   },
@@ -1231,7 +1234,7 @@ const JsonSchema220 = `{
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
+                          "maxLength": 15,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -1255,6 +1258,7 @@ const JsonSchema220 = `{
                           "type": "boolean"
                         },
                         "targetPort": {
+                          "description": "The port number should be unique.",
                           "type": "integer"
                         }
                       },
@@ -1493,7 +1497,7 @@ const JsonSchema220 = `{
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
+                          "maxLength": 15,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -1517,6 +1521,7 @@ const JsonSchema220 = `{
                           "type": "boolean"
                         },
                         "targetPort": {
+                          "description": "The port number should be unique.",
                           "type": "integer"
                         }
                       },
@@ -1591,7 +1596,7 @@ const JsonSchema220 = `{
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
+                          "maxLength": 15,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -1615,6 +1620,7 @@ const JsonSchema220 = `{
                           "type": "boolean"
                         },
                         "targetPort": {
+                          "description": "The port number should be unique.",
                           "type": "integer"
                         }
                       },


### PR DESCRIPTION

Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
use endpoint name as container port name and service port name if <= 15 chars. if > 15 chars (devfile spec before the change to shorten endpoint name limit), use `port-<portNumber>`

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
Fixes https://github.com/devfile/api/issues/700

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
