### PR TITLE
Add Replicas field to DeploymentParams struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
 	k8s.io/klog v1.0.0
-	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471 // indirect
+	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471
 	sigs.k8s.io/controller-runtime v0.9.5
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
 	k8s.io/klog v1.0.0
+	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471 // indirect
 	sigs.k8s.io/controller-runtime v0.9.5
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -2,8 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"k8s.io/utils/pointer"
-
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
 	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
@@ -159,7 +157,7 @@ type DeploymentParams struct {
 	Containers        []corev1.Container
 	Volumes           []corev1.Volume
 	PodSelectorLabels map[string]string
-	Replicas          int32
+	Replicas          *int32
 }
 
 // GetDeployment gets a deployment object
@@ -189,8 +187,8 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 		Spec:       *getDeploymentSpec(deploySpecParams),
 	}
 
-	if deployParams.Replicas != 0 {
-		deployment.Spec.Replicas = pointer.Int32Ptr(deployParams.Replicas)
+	if deployParams.Replicas != nil {
+		deployment.Spec.Replicas = deployParams.Replicas
 	}
 
 	return deployment, nil

--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"fmt"
+	"k8s.io/utils/pointer"
 
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/pkg/devfile/parser"
@@ -158,6 +159,7 @@ type DeploymentParams struct {
 	Containers        []corev1.Container
 	Volumes           []corev1.Volume
 	PodSelectorLabels map[string]string
+	Replicas          int32
 }
 
 // GetDeployment gets a deployment object
@@ -185,6 +187,10 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 		TypeMeta:   deployParams.TypeMeta,
 		ObjectMeta: deployParams.ObjectMeta,
 		Spec:       *getDeploymentSpec(deploySpecParams),
+	}
+
+	if deployParams.Replicas != 0 {
+		deployment.Spec.Replicas = pointer.Int32Ptr(deployParams.Replicas)
 	}
 
 	return deployment, nil

--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -184,11 +184,7 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 	deployment := &appsv1.Deployment{
 		TypeMeta:   deployParams.TypeMeta,
 		ObjectMeta: deployParams.ObjectMeta,
-		Spec:       *getDeploymentSpec(deploySpecParams),
-	}
-
-	if deployParams.Replicas != nil {
-		deployment.Spec.Replicas = deployParams.Replicas
+		Spec:       *getDeploymentSpec(deploySpecParams, deployParams),
 	}
 
 	return deployment, nil

--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -173,6 +173,7 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 	deploySpecParams := deploymentSpecParams{
 		PodTemplateSpec:   *getPodTemplateSpec(podTemplateSpecParams),
 		PodSelectorLabels: deployParams.PodSelectorLabels,
+		Replicas:          deployParams.Replicas,
 	}
 
 	containerAnnotations, err := getContainerAnnotations(devfileObj, common.DevfileOptions{})
@@ -184,7 +185,7 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 	deployment := &appsv1.Deployment{
 		TypeMeta:   deployParams.TypeMeta,
 		ObjectMeta: deployParams.ObjectMeta,
-		Spec:       *getDeploymentSpec(deploySpecParams, deployParams),
+		Spec:       *getDeploymentSpec(deploySpecParams),
 	}
 
 	return deployment, nil

--- a/pkg/devfile/generator/generators_test.go
+++ b/pkg/devfile/generator/generators_test.go
@@ -1051,7 +1051,7 @@ func TestGetDeployment(t *testing.T) {
 					},
 				},
 				Containers: containers,
-				Replicas:   1,
+				Replicas:   pointer.Int32Ptr(1),
 			},
 			expected: appsv1.Deployment{
 				ObjectMeta: objectMetaDedicatedPod,

--- a/pkg/devfile/generator/generators_test.go
+++ b/pkg/devfile/generator/generators_test.go
@@ -6,6 +6,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 	"reflect"
 	"strings"
 	"testing"
@@ -1000,14 +1001,6 @@ func TestGetDeployment(t *testing.T) {
 			Name: "container2",
 		},
 	}
-	deploymentParams := DeploymentParams{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				"preserved-key": "preserved-value",
-			},
-		},
-		Containers: containers,
-	}
 
 	objectMeta := metav1.ObjectMeta{
 		Annotations: map[string]string{
@@ -1027,6 +1020,7 @@ func TestGetDeployment(t *testing.T) {
 	tests := []struct {
 		name                string
 		containerComponents []v1.Component
+		deploymentParams    DeploymentParams
 		expected            appsv1.Deployment
 	}{
 		{
@@ -1050,6 +1044,15 @@ func TestGetDeployment(t *testing.T) {
 					},
 				}, &trueBool),
 			},
+			deploymentParams: DeploymentParams{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"preserved-key": "preserved-value",
+					},
+				},
+				Containers: containers,
+				Replicas:   1,
+			},
 			expected: appsv1.Deployment{
 				ObjectMeta: objectMetaDedicatedPod,
 				Spec: appsv1.DeploymentSpec{
@@ -1065,6 +1068,7 @@ func TestGetDeployment(t *testing.T) {
 							Containers: containers,
 						},
 					},
+					Replicas: pointer.Int32Ptr(1),
 				},
 			},
 		},
@@ -1086,6 +1090,14 @@ func TestGetDeployment(t *testing.T) {
 						"key2": "value2",
 					},
 				}, nil),
+			},
+			deploymentParams: DeploymentParams{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"preserved-key": "preserved-value",
+					},
+				},
+				Containers: containers,
 			},
 			expected: appsv1.Deployment{
 				ObjectMeta: objectMeta,
@@ -1125,7 +1137,7 @@ func TestGetDeployment(t *testing.T) {
 			devObj := parser.DevfileObj{
 				Data: mockDevfileData,
 			}
-			deploy, err := GetDeployment(devObj, deploymentParams)
+			deploy, err := GetDeployment(devObj, tt.deploymentParams)
 			// Checks for unexpected error cases
 			if err != nil {
 				t.Errorf("TestGetDeployment(): unexpected error %v", err)

--- a/pkg/devfile/generator/utils.go
+++ b/pkg/devfile/generator/utils.go
@@ -236,7 +236,7 @@ type deploymentSpecParams struct {
 }
 
 // getDeploymentSpec gets a deployment spec
-func getDeploymentSpec(deploySpecParams deploymentSpecParams) *appsv1.DeploymentSpec {
+func getDeploymentSpec(deploySpecParams deploymentSpecParams, deployParams DeploymentParams) *appsv1.DeploymentSpec {
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Strategy: appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
@@ -245,6 +245,10 @@ func getDeploymentSpec(deploySpecParams deploymentSpecParams) *appsv1.Deployment
 			MatchLabels: deploySpecParams.PodSelectorLabels,
 		},
 		Template: deploySpecParams.PodTemplateSpec,
+	}
+
+	if deployParams.Replicas != nil {
+		deploymentSpec.Replicas = deployParams.Replicas
 	}
 
 	return deploymentSpec

--- a/pkg/devfile/generator/utils.go
+++ b/pkg/devfile/generator/utils.go
@@ -233,10 +233,11 @@ func getPodTemplateSpec(podTemplateSpecParams podTemplateSpecParams) *corev1.Pod
 type deploymentSpecParams struct {
 	PodTemplateSpec   corev1.PodTemplateSpec
 	PodSelectorLabels map[string]string
+	Replicas          *int32
 }
 
 // getDeploymentSpec gets a deployment spec
-func getDeploymentSpec(deploySpecParams deploymentSpecParams, deployParams DeploymentParams) *appsv1.DeploymentSpec {
+func getDeploymentSpec(deploySpecParams deploymentSpecParams) *appsv1.DeploymentSpec {
 	deploymentSpec := &appsv1.DeploymentSpec{
 		Strategy: appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
@@ -245,10 +246,7 @@ func getDeploymentSpec(deploySpecParams deploymentSpecParams, deployParams Deplo
 			MatchLabels: deploySpecParams.PodSelectorLabels,
 		},
 		Template: deploySpecParams.PodTemplateSpec,
-	}
-
-	if deployParams.Replicas != nil {
-		deploymentSpec.Replicas = deployParams.Replicas
+		Replicas: deploySpecParams.Replicas,
 	}
 
 	return deploymentSpec


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Adds `Replicas` field to `DeploymentParams` struct. This will help initialize a Deployment with Replica set to what the tooling would like to have. By default, library doesn't set it to anything at the moment.

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
https://github.com/redhat-developer/odo/issues/5347

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
