### PR TITLE
906- variable substitution in kubernetes uri content

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,106 +1,121 @@
-schemaVersion: 2.2.0-latest
-metadata:
-  name: nodejs
-  version: 1.0.0
-  attributes:
-    alpha.build-dockerfile: /relative/path/to/Dockerfile
-variables:
-  test: testValue
-parent:
-  # uri: https://raw.githubusercontent.com/odo-devfiles/registry/master/devfiles/nodejs/devfile.yaml
-  id: nodejs
-  registryUrl: "https://registry.devfile.io"
-  version: latest
-  commands:
-  - id: install
-    exec:
-      component: runtime
-      commandLine: npm install
-      workingDir: /project-starter
-      group:
-        kind: build
-        isDefault: true
-starterProjects:
-- name: nodejs-starter2
-  git:
-    remotes:
-      origin: https://github.com/odo-devfiles/nodejs-ex.git
 components:
-- name: runtime2
-  attributes:
-    tool: console-import
-    import:
-      strategy: Dockerfile
-  container:
-    endpoints:
-    - name: http-8888
-      targetPort: 8888
-    image: registry.access.redhat.com/ubi8/nodejs-12:1-45
-    memoryLimit: 1024Mi
-    mountSources: true
-    sourceMapping: /project
-    command:
-      - npm install
-- name: runtime3
-  attributes:
-    tool: odo
-    cli:
-      usage: deploy
-  container:
-    endpoints:
-    - name: http-8080
-      targetPort: 8080
-    image: registry.access.redhat.com/ubi8/nodejs-12:1-45
-    memoryLimit: 1024Mi
-    mountSources: true
-    sourceMapping: /project
-- name: runtime4
-  attributes:
-    tool: workspace-operator
-  container:
-    endpoints:
-    - name: http-9090
-      targetPort: 9090
-    image: "{{invalid-var}}"
-    memoryLimit: 1024Mi
-    mountSources: true
-    sourceMapping: /project
-commands:
-- exec:
-    commandLine: npm install
-    component: runtime2
-    group:
-      isDefault: false
-      kind: build
-    workingDir: "{{test}}"
-  id: install2
-  attributes:
-    tool: odo
-    mandatory: false
-- exec:
-    commandLine: npm start
-    component: runtime2
-    group:
-      isDefault: false
-      kind: run
-    workingDir: /project
-  id: run2
-  attributes:
-    tool: odo
-    mandatory: true
-- exec:
-    commandLine: npm run debug
-    component: runtime2
-    group:
-      isDefault: false
-      kind: debug
-    workingDir: /project
-  id: debug2
-- exec:
-    commandLine: npm test
-    component: runtime2
-    group:
-      isDefault: false
-      kind: test
-    workingDir: /project
-  id: test2
+  - kubernetes:
+      endpoints:
+        - name: jsct05850
+          secure: false
+          targetPort: 4061
+        - exposure: internal
+          name: fttrf05851
+          secure: false
+          targetPort: 2794
+        - name: pediv05852
+          path: /Path_GpjjJ
+          secure: false
+          targetPort: 4061
+        - name: w05853
+          protocol: tcp
+          secure: false
+          targetPort: 4061
+        - name: ve05854
+          path: /Path_rUnibQXIL
+          secure: true
+          targetPort: 4061
+    name: sxi05849
+  - kubernetes:
+      endpoints:
+        - name: bj05856
+          path: /Path_QEqKHLrqVSS
+          secure: false
+          targetPort: 1985
+        - exposure: internal
+          name: udbeo05857
+          secure: true
+          targetPort: 1985
+        - exposure: internal
+          name: yol05858
+          protocol: wss
+          secure: false
+          targetPort: 1985
+    name: lsk05855
+  - kubernetes: {}
+    name: shf05859
+  - kubernetes:
+      endpoints:
+        - name: grmex05861
+          protocol: tcp
+          secure: true
+          targetPort: 429
+        - name: ork05862
+          path: /Path_MofEhbd
+          protocol: wss
+          secure: false
+          targetPort: 3214
+    name: zrk05860
+  - kubernetes: {}
+    name: igh05863
+  - kubernetes:
+      endpoints:
+        - name: emf05865
+          path: /Path_ZkPBw
+          protocol: wss
+          secure: true
+          targetPort: 970
+        - name: wqnaf05866
+          path: /Path_UpxBmbMJDr
+          secure: true
+          targetPort: 1863
+        - exposure: internal
+          name: rbk05867
+          path: /Path_TTlXWYESKJwelJ
+          protocol: udp
+          secure: true
+          targetPort: 2706
+        - exposure: none
+          name: zjiv05868
+          path: /Path_JUQlS
+          protocol: udp
+          secure: true
+          targetPort: 970
+    name: ecw05864
+  - kubernetes:
+      endpoints:
+        - exposure: none
+          name: i05870
+          protocol: tcp
+          secure: true
+          targetPort: 565
+        - name: yln05871
+          protocol: https
+          secure: true
+          targetPort: 4386
+        - name: qyrrk05872
+          path: /Path_gtsayNeeuFJ
+          secure: false
+          targetPort: 3546
+        - exposure: none
+          name: vv05873
+          secure: false
+          targetPort: 2295
+        - name: dat05874
+          path: /Path_kWxdWGLbCmZYf
+          protocol: wss
+          secure: false
+          targetPort: 2474
+    name: lgv05869
+  - kubernetes:
+      endpoints:
+        - name: koac05876
+          secure: false
+          targetPort: 4318
+        - name: lelw05877
+          path: /Path_EhnGCYPmFHrZPA
+          protocol: ws
+          secure: true
+          targetPort: 592
+        - name: j05878
+          protocol: tcp
+          secure: false
+          targetPort: 4318
+    name: qcu05875
+metadata: {}
+schemaVersion: 2.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/devfile/library
 go 1.15
 
 require (
-	github.com/devfile/api/v2 v2.0.0-20220309195345-48ebbf1e51cf
+	github.com/devfile/api/v2 v2.0.0-20220614133608-351f05b7c2b1
 	github.com/fatih/color v1.7.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/api/v2 v2.0.0-20220309195345-48ebbf1e51cf h1:FkwAOQtepscB5B0j++9S/eoicXj707MaP5HPIScz0sA=
-github.com/devfile/api/v2 v2.0.0-20220309195345-48ebbf1e51cf/go.mod h1:kLX/nW93gigOHXK3NLeJL2fSS/sgEe+OHu8bo3aoOi4=
+github.com/devfile/api/v2 v2.0.0-20220614133608-351f05b7c2b1 h1:rwhw0TQUCS/qT4iDsoOPV/AaopUiYYYXs5zXeX1n6Ts=
+github.com/devfile/api/v2 v2.0.0-20220614133608-351f05b7c2b1/go.mod h1:dN7xFrOVG+iPqn4UKGibXLd5oVsdE8XyK9OEb5JL3aI=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/pkg/devfile/parse_test.go
+++ b/pkg/devfile/parse_test.go
@@ -105,12 +105,12 @@ schemaVersion: 2.2.0
 		args parser.ParserArgs
 	}
 	tests := []struct {
-		name            string
-		args            args
-		wantVarWarning  variables.VariableWarning
-		wantCommandLine string
+		name                 string
+		args                 args
+		wantVarWarning       variables.VariableWarning
+		wantCommandLine      string
 		wantKubernetesInline string
-		wantVariables   map[string]string
+		wantVariables        map[string]string
 	}{
 		{
 			name: "with external overriding variables",
@@ -123,7 +123,7 @@ schemaVersion: 2.2.0
 				},
 			},
 			wantKubernetesInline: "image: my-python-image:bar",
-			wantCommandLine: "./main bar",
+			wantCommandLine:      "./main bar",
 			wantVariables: map[string]string{
 				"PARAMS": "bar",
 			},
@@ -145,7 +145,7 @@ schemaVersion: 2.2.0
 				},
 			},
 			wantKubernetesInline: "image: my-python-image:foo",
-			wantCommandLine: "./main foo",
+			wantCommandLine:      "./main foo",
 			wantVariables: map[string]string{
 				"PARAMS": "foo",
 				"OTHER":  "other",
@@ -167,7 +167,7 @@ schemaVersion: 2.2.0
 				},
 			},
 			wantKubernetesInline: "image: my-python-image:baz",
-			wantCommandLine: "./main baz",
+			wantCommandLine:      "./main baz",
 			wantVariables: map[string]string{
 				"PARAMS": "baz",
 			},
@@ -210,8 +210,7 @@ schemaVersion: 2.2.0
 			}
 
 			if kubenetesComponent.Attributes != nil {
-				if originalUri := kubenetesComponent.Attributes.GetString(KubeComponentOriginalURIKey, &err);
-				err != nil || originalUri != "http://127.0.0.1:8080/outerloop-deploy.yaml"{
+				if originalUri := kubenetesComponent.Attributes.GetString(KubeComponentOriginalURIKey, &err); err != nil || originalUri != "http://127.0.0.1:8080/outerloop-deploy.yaml" {
 					t.Errorf("ParseDevfileAndValidate() should set kubenetesComponent.Attributes, '%s', expected http://127.0.0.1:8080/outerloop-deploy.yaml, got %s",
 						KubeComponentOriginalURIKey, originalUri)
 				}

--- a/pkg/devfile/parse_test.go
+++ b/pkg/devfile/parse_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestParseDevfileAndValidate(t *testing.T) {
 	convertUriToInline := false
-	K8sLikeComponentOriginalURIKey := "devfile.io/k8sLikeComponent-originalURI"
+	K8sLikeComponentOriginalURIKey := "api.devfile.io/k8sLikeComponent-originalURI"
 	outerloopDeployContent := `
 kind: Deployment
 apiVersion: apps/v1

--- a/pkg/devfile/parser/context/context.go
+++ b/pkg/devfile/parser/context/context.go
@@ -35,6 +35,9 @@ type DevfileCtx struct {
 
 	// filesystem for devfile
 	fs filesystem.Filesystem
+
+	// devfile kubernetes components has been coverted from uri to inlined in memory
+	convertUriToInlined bool
 }
 
 // NewDevfileCtx returns a new DevfileCtx type object
@@ -142,4 +145,14 @@ func (d *DevfileCtx) SetAbsPath() (err error) {
 
 	return nil
 
+}
+
+// GetConvertUriToInlined func returns if the devfile kubernetes comp has been converted from uri to inlined
+func (d *DevfileCtx) GetConvertUriToInlined() bool {
+	return d.convertUriToInlined
+}
+
+// SetConvertUriToInlined sets if the devfile kubernetes comp has been converted from uri to inlined
+func (d *DevfileCtx) SetConvertUriToInlined(value bool) {
+	d.convertUriToInlined = value
 }

--- a/pkg/devfile/parser/data/v2/2.2.0/devfileJsonSchema220.go
+++ b/pkg/devfile/parser/data/v2/2.2.0/devfileJsonSchema220.go
@@ -372,7 +372,7 @@ const JsonSchema220 = `{
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -491,7 +491,7 @@ const JsonSchema220 = `{
                     }
                   },
                   "buildContext": {
-                    "description": "Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container",
+                    "description": "Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container",
                     "type": "string"
                   },
                   "devfileRegistry": {
@@ -644,7 +644,7 @@ const JsonSchema220 = `{
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -746,7 +746,7 @@ const JsonSchema220 = `{
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -1258,7 +1258,7 @@ const JsonSchema220 = `{
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -1377,7 +1377,7 @@ const JsonSchema220 = `{
                         }
                       },
                       "buildContext": {
-                        "description": "Path of source directory to establish build context. Defaults to ${PROJECT_ROOT} in the container",
+                        "description": "Path of source directory to establish build context. Defaults to ${PROJECT_SOURCE} in the container",
                         "type": "string"
                       },
                       "devfileRegistry": {
@@ -1521,7 +1521,7 @@ const JsonSchema220 = `{
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -1620,7 +1620,7 @@ const JsonSchema220 = `{
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },

--- a/pkg/devfile/parser/devfileobj.go
+++ b/pkg/devfile/parser/devfileobj.go
@@ -7,8 +7,8 @@ import (
 
 // Default filenames for create devfile
 const (
-	OutputDevfileYamlPath       = "devfile.yaml"
-	KubeComponentOriginalURIKey = "devfile.io/kubeComponent-originalURI"
+	OutputDevfileYamlPath          = "devfile.yaml"
+	K8sLikeComponentOriginalURIKey = "devfile.io/k8sLikeComponent-originalURI"
 )
 
 // DevfileObj is the runtime devfile object

--- a/pkg/devfile/parser/devfileobj.go
+++ b/pkg/devfile/parser/devfileobj.go
@@ -7,7 +7,7 @@ import (
 
 // Default filenames for create devfile
 const (
-	OutputDevfileYamlPath = "devfile.yaml"
+	OutputDevfileYamlPath       = "devfile.yaml"
 	KubeComponentOriginalURIKey = "devfile.io/kubeComponent-originalURI"
 )
 

--- a/pkg/devfile/parser/devfileobj.go
+++ b/pkg/devfile/parser/devfileobj.go
@@ -8,6 +8,7 @@ import (
 // Default filenames for create devfile
 const (
 	OutputDevfileYamlPath = "devfile.yaml"
+	KubeComponentOriginalURIKey = "devfile.io/kubeComponent-originalURI"
 )
 
 // DevfileObj is the runtime devfile object

--- a/pkg/devfile/parser/devfileobj.go
+++ b/pkg/devfile/parser/devfileobj.go
@@ -8,7 +8,7 @@ import (
 // Default filenames for create devfile
 const (
 	OutputDevfileYamlPath          = "devfile.yaml"
-	K8sLikeComponentOriginalURIKey = "devfile.io/k8sLikeComponent-originalURI"
+	K8sLikeComponentOriginalURIKey = "api.devfile.io/k8sLikeComponent-originalURI"
 )
 
 // DevfileObj is the runtime devfile object

--- a/pkg/devfile/parser/parse.go
+++ b/pkg/devfile/parser/parse.go
@@ -606,6 +606,7 @@ func setEndpoints(endpoints []v1.Endpoint) {
 	}
 }
 
+//parseKubeComponentFromURI iterate through all kubernetes components, and parse from uri and update the content to inlined field in devfileObj
 func parseKubeComponentFromURI(devObj DevfileObj) error {
 	getKubeCompOptions := common.DevfileOptions{
 		ComponentOptions: common.ComponentOptions{
@@ -631,6 +632,7 @@ func parseKubeComponentFromURI(devObj DevfileObj) error {
 	return nil
 }
 
+//convertKubeCompUriToInlined read in kubernetes resources definition from uri and converts to kubernetest inlined field
 func convertKubeCompUriToInlined(component *v1.Component, d devfileCtx.DevfileCtx) error{
 	uri := component.Kubernetes.Uri
 	// validate URI

--- a/pkg/devfile/parser/writer.go
+++ b/pkg/devfile/parser/writer.go
@@ -39,7 +39,6 @@ func (d *DevfileObj) WriteYamlDevfile() error {
 	return nil
 }
 
-
 func restoreKubeCompURI(devObj *DevfileObj) error {
 	getKubeCompOptions := common.DevfileOptions{
 		ComponentOptions: common.ComponentOptions{
@@ -58,7 +57,7 @@ func restoreKubeCompURI(devObj *DevfileObj) error {
 		}
 		kubeComp.Kubernetes.Uri = uri
 		kubeComp.Kubernetes.Inlined = ""
-		delete(kubeComp.Attributes,KubeComponentOriginalURIKey)
+		delete(kubeComp.Attributes, KubeComponentOriginalURIKey)
 		err = devObj.Data.UpdateComponent(kubeComp)
 		if err != nil {
 			return err

--- a/pkg/devfile/parser/writer.go
+++ b/pkg/devfile/parser/writer.go
@@ -1,6 +1,9 @@
 package parser
 
 import (
+	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	apiAttributes "github.com/devfile/api/v2/pkg/attributes"
+	"github.com/devfile/library/pkg/devfile/parser/data/v2/common"
 	"sigs.k8s.io/yaml"
 
 	"github.com/devfile/library/pkg/testingutil/filesystem"
@@ -10,7 +13,10 @@ import (
 
 // WriteYamlDevfile creates a devfile.yaml file
 func (d *DevfileObj) WriteYamlDevfile() error {
-
+	err := restoreKubeCompURI(d)
+	if err != nil {
+		return errors.Wrapf(err, "failed to restore kubernetes component uri field")
+	}
 	// Encode data into YAML format
 	yamlData, err := yaml.Marshal(d.Data)
 	if err != nil {
@@ -28,5 +34,33 @@ func (d *DevfileObj) WriteYamlDevfile() error {
 
 	// Successful
 	klog.V(2).Infof("devfile yaml created at: '%s'", OutputDevfileYamlPath)
+	return nil
+}
+
+
+func restoreKubeCompURI(devObj *DevfileObj) error {
+	getKubeCompOptions := common.DevfileOptions{
+		ComponentOptions: common.ComponentOptions{
+			ComponentType: v1.KubernetesComponentType,
+		},
+	}
+	kubeComponents, err := devObj.Data.GetComponents(getKubeCompOptions)
+	if err != nil {
+		return err
+	}
+	for _, kubeComp := range kubeComponents {
+		var keyNotFoundErr = &apiAttributes.KeyNotFoundError{Key: KubeComponentOriginalURIKey}
+		uri := kubeComp.Attributes.GetString(KubeComponentOriginalURIKey, &err)
+		if err != nil && err.Error() != keyNotFoundErr.Error() {
+			return err
+		}
+		kubeComp.Kubernetes.Uri = uri
+		kubeComp.Kubernetes.Inlined = ""
+		delete(kubeComp.Attributes,KubeComponentOriginalURIKey)
+		err = devObj.Data.UpdateComponent(kubeComp)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/devfile/parser/writer.go
+++ b/pkg/devfile/parser/writer.go
@@ -13,6 +13,8 @@ import (
 
 // WriteYamlDevfile creates a devfile.yaml file
 func (d *DevfileObj) WriteYamlDevfile() error {
+
+	// Check kubernetes components, and restore original uri content
 	err := restoreKubeCompURI(d)
 	if err != nil {
 		return errors.Wrapf(err, "failed to restore kubernetes component uri field")

--- a/pkg/devfile/parser/writer_test.go
+++ b/pkg/devfile/parser/writer_test.go
@@ -18,7 +18,9 @@ func TestWriteYamlDevfile(t *testing.T) {
 		schemaVersion = "2.2.0"
 		testName      = "TestName"
 		uri           = "./relative/path/deploy.yaml"
-		attributes    = apiAttributes.Attributes{}.PutString(KubeComponentOriginalURIKey, uri)
+		uri2          = "./relative/path/deploy2.yaml"
+		attributes    = apiAttributes.Attributes{}.PutString(K8sLikeComponentOriginalURIKey, uri)
+		attributes2   = apiAttributes.Attributes{}.PutString(K8sLikeComponentOriginalURIKey, uri2)
 	)
 
 	t.Run("write yaml devfile", func(t *testing.T) {
@@ -53,6 +55,19 @@ func TestWriteYamlDevfile(t *testing.T) {
 										},
 									},
 								},
+								{
+									Name:       "openshiftComp",
+									Attributes: attributes2,
+									ComponentUnion: v1.ComponentUnion{
+										Openshift: &v1.OpenshiftComponent{
+											K8sLikeComponent: v1.K8sLikeComponent{
+												K8sLikeComponentLocation: v1.K8sLikeComponentLocation{
+													Inlined: "placeholder",
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -75,11 +90,14 @@ func TestWriteYamlDevfile(t *testing.T) {
 			t.Errorf("TestWriteYamlDevfile() unexpected error: '%v'", err)
 		} else {
 			content := string(data)
-			if strings.Contains(content, "inlined") || strings.Contains(content, KubeComponentOriginalURIKey) {
-				t.Errorf("TestWriteYamlDevfile() failed: kubernetes component should not contain inlined or %s", KubeComponentOriginalURIKey)
+			if strings.Contains(content, "inlined") || strings.Contains(content, K8sLikeComponentOriginalURIKey) {
+				t.Errorf("TestWriteYamlDevfile() failed: kubernetes component should not contain inlined or %s", K8sLikeComponentOriginalURIKey)
 			}
 			if !strings.Contains(content, fmt.Sprintf("uri: %s", uri)) {
 				t.Errorf("TestWriteYamlDevfile() failed: kubernetes component does not contain uri")
+			}
+			if !strings.Contains(content, fmt.Sprintf("uri: %s", uri2)) {
+				t.Errorf("TestWriteYamlDevfile() failed: openshift component does not contain uri")
 			}
 		}
 	})

--- a/pkg/devfile/parser/writer_test.go
+++ b/pkg/devfile/parser/writer_test.go
@@ -2,14 +2,14 @@ package parser
 
 import (
 	"fmt"
-	"strings"
-	"testing"
-	apiAttributes "github.com/devfile/api/v2/pkg/attributes"
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	apiAttributes "github.com/devfile/api/v2/pkg/attributes"
 	devfilepkg "github.com/devfile/api/v2/pkg/devfile"
 	devfileCtx "github.com/devfile/library/pkg/devfile/parser/context"
 	v2 "github.com/devfile/library/pkg/devfile/parser/data/v2"
 	"github.com/devfile/library/pkg/testingutil/filesystem"
+	"strings"
+	"testing"
 )
 
 func TestWriteYamlDevfile(t *testing.T) {
@@ -17,8 +17,8 @@ func TestWriteYamlDevfile(t *testing.T) {
 	var (
 		schemaVersion = "2.2.0"
 		testName      = "TestName"
-		uri = "./relative/path/deploy.yaml"
-		attributes = apiAttributes.Attributes{}.PutString(KubeComponentOriginalURIKey, uri)
+		uri           = "./relative/path/deploy.yaml"
+		attributes    = apiAttributes.Attributes{}.PutString(KubeComponentOriginalURIKey, uri)
 	)
 
 	t.Run("write yaml devfile", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestWriteYamlDevfile(t *testing.T) {
 						DevWorkspaceTemplateSpecContent: v1.DevWorkspaceTemplateSpecContent{
 							Components: []v1.Component{
 								{
-									Name: "kubeComp",
+									Name:       "kubeComp",
 									Attributes: attributes,
 									ComponentUnion: v1.ComponentUnion{
 										Kubernetes: &v1.KubernetesComponent{
@@ -78,7 +78,7 @@ func TestWriteYamlDevfile(t *testing.T) {
 			if strings.Contains(content, "inlined") || strings.Contains(content, KubeComponentOriginalURIKey) {
 				t.Errorf("TestWriteYamlDevfile() failed: kubernetes component should not contain inlined or %s", KubeComponentOriginalURIKey)
 			}
-			if !strings.Contains(content, fmt.Sprintf("uri: %s",uri)) {
+			if !strings.Contains(content, fmt.Sprintf("uri: %s", uri)) {
 				t.Errorf("TestWriteYamlDevfile() failed: kubernetes component does not contain uri")
 			}
 		}

--- a/pkg/devfile/parser/writer_test.go
+++ b/pkg/devfile/parser/writer_test.go
@@ -74,6 +74,7 @@ func TestWriteYamlDevfile(t *testing.T) {
 				},
 			},
 		}
+		devfileObj.Ctx.SetConvertUriToInlined(true)
 
 		// test func()
 		err := devfileObj.WriteYamlDevfile()

--- a/pkg/devfile/parser/writer_test.go
+++ b/pkg/devfile/parser/writer_test.go
@@ -1,8 +1,10 @@
 package parser
 
 import (
+	"fmt"
+	"strings"
 	"testing"
-
+	apiAttributes "github.com/devfile/api/v2/pkg/attributes"
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	devfilepkg "github.com/devfile/api/v2/pkg/devfile"
 	devfileCtx "github.com/devfile/library/pkg/devfile/parser/context"
@@ -13,8 +15,10 @@ import (
 func TestWriteYamlDevfile(t *testing.T) {
 
 	var (
-		schemaVersion = "2.0.0"
+		schemaVersion = "2.2.0"
 		testName      = "TestName"
+		uri = "./relative/path/deploy.yaml"
+		attributes = apiAttributes.Attributes{}.PutString(KubeComponentOriginalURIKey, uri)
 	)
 
 	t.Run("write yaml devfile", func(t *testing.T) {
@@ -33,6 +37,25 @@ func TestWriteYamlDevfile(t *testing.T) {
 							Name: testName,
 						},
 					},
+					DevWorkspaceTemplateSpec: v1.DevWorkspaceTemplateSpec{
+						DevWorkspaceTemplateSpecContent: v1.DevWorkspaceTemplateSpecContent{
+							Components: []v1.Component{
+								{
+									Name: "kubeComp",
+									Attributes: attributes,
+									ComponentUnion: v1.ComponentUnion{
+										Kubernetes: &v1.KubernetesComponent{
+											K8sLikeComponent: v1.K8sLikeComponent{
+												K8sLikeComponentLocation: v1.K8sLikeComponentLocation{
+													Inlined: "placeholder",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		}
@@ -45,6 +68,19 @@ func TestWriteYamlDevfile(t *testing.T) {
 
 		if _, err := fs.Stat(OutputDevfileYamlPath); err != nil {
 			t.Errorf("TestWriteYamlDevfile() unexpected error: '%v'", err)
+		}
+
+		data, err := fs.ReadFile(OutputDevfileYamlPath)
+		if err != nil {
+			t.Errorf("TestWriteYamlDevfile() unexpected error: '%v'", err)
+		} else {
+			content := string(data)
+			if strings.Contains(content, "inlined") || strings.Contains(content, KubeComponentOriginalURIKey) {
+				t.Errorf("TestWriteYamlDevfile() failed: kubernetes component should not contain inlined or %s", KubeComponentOriginalURIKey)
+			}
+			if !strings.Contains(content, fmt.Sprintf("uri: %s",uri)) {
+				t.Errorf("TestWriteYamlDevfile() failed: kubernetes component does not contain uri")
+			}
 		}
 	})
 }

--- a/tests/v2/utils/library/test_utils.go
+++ b/tests/v2/utils/library/test_utils.go
@@ -179,8 +179,9 @@ func validateDevfile(devfile *commonUtils.TestDevfile) error {
 	var err error
 
 	commonUtils.LogInfoMessage(fmt.Sprintf("Parse and Validate %s : ", devfile.FileName))
-
+	parseK8sDefinitionFromURI := false
 	parserArgs.Path = devfile.FileName
+	parserArgs.ConvertKubernetesContentInUri = &parseK8sDefinitionFromURI
 	libraryObj, warning, err := devfilepkg.ParseDevfileAndValidate(parserArgs)
 
 	if len(warning.Commands) > 0 || len(warning.Components) > 0 || len(warning.Projects) > 0 || len(warning.StarterProjects) > 0 {
@@ -189,6 +190,7 @@ func validateDevfile(devfile *commonUtils.TestDevfile) error {
 
 	if err != nil {
 		commonUtils.LogErrorMessage(fmt.Sprintf("From ParseDevfileAndValidate %v : ", err))
+		return err
 	} else {
 		follower := devfile.Follower.(DevfileFollower)
 		follower.LibraryData = libraryObj.Data


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR converts kubernetest `uri` field to the `inlined` field with actual content in the `devfileObj` object in memory; so that the grobal variable defined can be substituted. An attribute `devfile.io/kubeComponent-originalURI` will be added to the kubernetes component as well. 
The PR also modified writer to check for the specific attribute and restore the uri back before write to the devfile; so that we are not modifying user's devfile content. 


### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/906

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
