### PR TITLE
Change from internal fs to afero fs

### DIFF
--- a/pkg/devfile/parser/reader.go
+++ b/pkg/devfile/parser/reader.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/devfile/library/pkg/testingutil/filesystem"
 	"github.com/devfile/library/pkg/util"
 	"github.com/pkg/errors"
+	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 	k8yaml "sigs.k8s.io/yaml"
 
@@ -39,7 +39,7 @@ type KubernetesResources struct {
 // It returns all the parsed Kubernetes objects as an array of interface.
 // Consumers interested in the Kubernetes resources are expected to Unmarshal
 // it to the struct of the respective Kubernetes resource.
-func ReadKubernetesYaml(src YamlSrc, fs filesystem.Filesystem) ([]interface{}, error) {
+func ReadKubernetesYaml(src YamlSrc, fs afero.Afero) ([]interface{}, error) {
 
 	var data []byte
 	var err error

--- a/pkg/devfile/parser/reader_test.go
+++ b/pkg/devfile/parser/reader_test.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/devfile/library/pkg/testingutil/filesystem"
 	"github.com/devfile/library/pkg/util"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +16,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 	const serverIP = "127.0.0.1:9080"
 	var data []byte
 
-	fs := filesystem.DefaultFs{}
+	fs := afero.Afero{Fs: afero.NewOsFs()}
 	absPath, err := util.GetAbsPath("../../../tests/yamls/resources.yaml")
 	if err != nil {
 		t.Error(err)
@@ -56,7 +56,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 	tests := []struct {
 		name                string
 		src                 YamlSrc
-		fs                  filesystem.Filesystem
+		fs                  afero.Afero
 		wantErr             bool
 		wantDeploymentNames []string
 		wantServiceNames    []string
@@ -69,7 +69,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				URL: "http://" + serverIP,
 			},
-			fs:                  filesystem.DefaultFs{},
+			fs:                  fs,
 			wantDeploymentNames: []string{"deploy-sample", "deploy-sample-2"},
 			wantServiceNames:    []string{"service-sample", "service-sample-2"},
 			wantRouteNames:      []string{"route-sample", "route-sample-2"},
@@ -81,7 +81,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				Path: "../../../tests/yamls/resources.yaml",
 			},
-			fs:                  filesystem.DefaultFs{},
+			fs:                  fs,
 			wantDeploymentNames: []string{"deploy-sample", "deploy-sample-2"},
 			wantServiceNames:    []string{"service-sample", "service-sample-2"},
 			wantRouteNames:      []string{"route-sample", "route-sample-2"},
@@ -93,7 +93,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				Data: data,
 			},
-			fs:                  filesystem.DefaultFs{},
+			fs:                  fs,
 			wantDeploymentNames: []string{"deploy-sample", "deploy-sample-2"},
 			wantServiceNames:    []string{"service-sample", "service-sample-2"},
 			wantRouteNames:      []string{"route-sample", "route-sample-2"},
@@ -105,7 +105,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				URL: "http://badurl",
 			},
-			fs:      filesystem.DefaultFs{},
+			fs:      fs,
 			wantErr: true,
 		},
 		{
@@ -113,7 +113,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				Path: "$%^&",
 			},
-			fs:      filesystem.DefaultFs{},
+			fs:      fs,
 			wantErr: true,
 		},
 		{
@@ -121,7 +121,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				Data: badData,
 			},
-			fs:      filesystem.DefaultFs{},
+			fs:      fs,
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?:
Updates the function's fs from internal to afero.

Why? Because 
- the internal fs belongs in the testing pkg `github.com/devfile/library/pkg/testingutil/filesystem`
- it makes sense to have a generic fs rather than an internal one for tools to adopt

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
Tests should pass