### PR TITLE
Filesystem is not required when reading from URL and Data

### DIFF
--- a/pkg/devfile/parser/reader.go
+++ b/pkg/devfile/parser/reader.go
@@ -17,6 +17,7 @@ package parser
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/devfile/library/pkg/util"
@@ -53,8 +54,9 @@ type KubernetesResources struct {
 // ReadKubernetesYaml reads a yaml Kubernetes file from either the Path, URL or Data provided.
 // It returns all the parsed Kubernetes objects as an array of interface.
 // Consumers interested in the Kubernetes resources are expected to Unmarshal
-// it to the struct of the respective Kubernetes resource.
-func ReadKubernetesYaml(src YamlSrc, fs afero.Afero) ([]interface{}, error) {
+// it to the struct of the respective Kubernetes resource. If a Path is being passed,
+// provide a filesystem, otherwise nil can be passed in
+func ReadKubernetesYaml(src YamlSrc, fs *afero.Afero) ([]interface{}, error) {
 
 	var data []byte
 	var err error
@@ -65,6 +67,9 @@ func ReadKubernetesYaml(src YamlSrc, fs afero.Afero) ([]interface{}, error) {
 			return nil, errors.Wrapf(err, "failed to download file %q", src.URL)
 		}
 	} else if src.Path != "" {
+		if fs == nil {
+			return nil, fmt.Errorf("cannot read from %s because fs passed in was nil", src.Path)
+		}
 		data, err = fs.ReadFile(src.Path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read yaml from path %q", src.Path)

--- a/pkg/devfile/parser/reader_test.go
+++ b/pkg/devfile/parser/reader_test.go
@@ -71,7 +71,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 	tests := []struct {
 		name                string
 		src                 YamlSrc
-		fs                  afero.Afero
+		fs                  *afero.Afero
 		wantErr             bool
 		wantDeploymentNames []string
 		wantServiceNames    []string
@@ -84,7 +84,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				URL: "http://" + serverIP,
 			},
-			fs:                  fs,
+			fs:                  nil,
 			wantDeploymentNames: []string{"deploy-sample", "deploy-sample-2"},
 			wantServiceNames:    []string{"service-sample", "service-sample-2"},
 			wantRouteNames:      []string{"route-sample", "route-sample-2"},
@@ -96,7 +96,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				Path: "../../../tests/yamls/resources.yaml",
 			},
-			fs:                  fs,
+			fs:                  &fs,
 			wantDeploymentNames: []string{"deploy-sample", "deploy-sample-2"},
 			wantServiceNames:    []string{"service-sample", "service-sample-2"},
 			wantRouteNames:      []string{"route-sample", "route-sample-2"},
@@ -104,11 +104,19 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			wantOtherNames:      []string{"pvc-sample", "pvc-sample-2"},
 		},
 		{
+			name: "Read the YAML from the Path with no fs passed",
+			src: YamlSrc{
+				Path: "../../../tests/yamls/resources.yaml",
+			},
+			fs:      nil,
+			wantErr: true,
+		},
+		{
 			name: "Read the YAML from the Data",
 			src: YamlSrc{
 				Data: data,
 			},
-			fs:                  fs,
+			fs:                  nil,
 			wantDeploymentNames: []string{"deploy-sample", "deploy-sample-2"},
 			wantServiceNames:    []string{"service-sample", "service-sample-2"},
 			wantRouteNames:      []string{"route-sample", "route-sample-2"},
@@ -120,7 +128,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				URL: "http://badurl",
 			},
-			fs:      fs,
+			fs:      nil,
 			wantErr: true,
 		},
 		{
@@ -128,7 +136,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				Path: "$%^&",
 			},
-			fs:      fs,
+			fs:      &fs,
 			wantErr: true,
 		},
 		{
@@ -136,7 +144,7 @@ func TestReadAndParseKubernetesYaml(t *testing.T) {
 			src: YamlSrc{
 				Data: badData,
 			},
-			fs:      fs,
+			fs:      nil,
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
Updated the method param to a nil, because a Filesystem is not required to be passed in if the src is URL or Data

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
N/A, but suggested in review here https://github.com/openshift/console/pull/12000#discussion_r985472126

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
Tests updated and should run successfully