### PR TITLE
Change func param signature to avoid unneccessary Ctx

### DIFF
--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -3988,7 +3988,7 @@ func Test_parseFromRegistry(t *testing.T) {
 				ImportReferenceUnion: v1.ImportReferenceUnion{
 					Id: registryId,
 				},
-				Version:     "2.1.0",
+				Version:     "2.1.1",
 				RegistryUrl: stagingRegistry,
 			},
 		},

--- a/pkg/devfile/parser/utils.go
+++ b/pkg/devfile/parser/utils.go
@@ -20,17 +20,18 @@ import (
 	"reflect"
 
 	devfilev1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/library/v2/pkg/devfile/parser/data"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
 )
 
 // GetDeployComponents gets the default deploy command associated components
-func GetDeployComponents(devfileObj DevfileObj) (map[string]string, error) {
+func GetDeployComponents(devfileData data.DevfileData) (map[string]string, error) {
 	deployCommandFilter := common.DevfileOptions{
 		CommandOptions: common.CommandOptions{
 			CommandGroupKind: devfilev1.DeployCommandGroupKind,
 		},
 	}
-	deployCommands, err := devfileObj.Data.GetCommands(deployCommandFilter)
+	deployCommands, err := devfileData.GetCommands(deployCommandFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func GetDeployComponents(devfileObj DevfileObj) (map[string]string, error) {
 			CommandType: devfilev1.ApplyCommandType,
 		},
 	}
-	applyCommands, err := devfileObj.Data.GetCommands(applyCommandFilter)
+	applyCommands, err := devfileData.GetCommands(applyCommandFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -77,14 +78,14 @@ func GetDeployComponents(devfileObj DevfileObj) (map[string]string, error) {
 }
 
 // GetImageBuildComponent gets the image build component from the deploy associated components
-func GetImageBuildComponent(devfileObj DevfileObj, deployAssociatedComponents map[string]string) (devfilev1.Component, error) {
+func GetImageBuildComponent(devfileData data.DevfileData, deployAssociatedComponents map[string]string) (devfilev1.Component, error) {
 	imageComponentFilter := common.DevfileOptions{
 		ComponentOptions: common.ComponentOptions{
 			ComponentType: devfilev1.ImageComponentType,
 		},
 	}
 
-	imageComponents, err := devfileObj.Data.GetComponents(imageComponentFilter)
+	imageComponents, err := devfileData.GetComponents(imageComponentFilter)
 	if err != nil {
 		return devfilev1.Component{}, err
 	}

--- a/pkg/devfile/parser/utils_test.go
+++ b/pkg/devfile/parser/utils_test.go
@@ -196,7 +196,7 @@ func TestGetDeployComponents(t *testing.T) {
 				Data: mockDevfileData,
 			}
 
-			componentMap, err := GetDeployComponents(devObj)
+			componentMap, err := GetDeployComponents(devObj.Data)
 			// Unexpected error
 			if (err != nil) != (tt.wantErr != nil) {
 				t.Errorf("TestGetDeployComponents() error: %v, wantErr %v", err, tt.wantErr)
@@ -372,7 +372,7 @@ func TestGetImageBuildComponent(t *testing.T) {
 				Data: mockDevfileData,
 			}
 
-			component, err := GetImageBuildComponent(devObj, tt.deployAssociatedComponents)
+			component, err := GetImageBuildComponent(devObj.Data, tt.deployAssociatedComponents)
 			// Unexpected error
 			if (err != nil) != (tt.wantErr != nil) {
 				t.Errorf("TestGetImageBuildComponent() error: %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?:
Changes the util func param signature to take in Devfile data rather than Devfile object. Because we dont need DevfileObj.Ctx and is unnecessary export available in the function

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
Tests should pass