### PR TITLE
Add support for container-overrides attribute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.21.3
+	k8s.io/apiextensions-apiserver v0.21.3
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
 	k8s.io/klog v1.0.0

--- a/pkg/devfile/generator/utils.go
+++ b/pkg/devfile/generator/utils.go
@@ -18,13 +18,14 @@ package generator
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/go-multierror"
 	"path/filepath"
 	"reflect"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
-
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/library/v2/pkg/devfile/parser"
+	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
 	buildv1 "github.com/openshift/api/build/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,9 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-
-	"github.com/devfile/library/v2/pkg/devfile/parser"
-	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
 )
 
 const ContainerOverridesAttribute = "container-overrides"

--- a/pkg/devfile/generator/utils_test.go
+++ b/pkg/devfile/generator/utils_test.go
@@ -16,27 +16,29 @@
 package generator
 
 import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
+
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
-	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/api/v2/pkg/attributes"
+	"github.com/devfile/library/v2/pkg/devfile/parser"
+	"github.com/devfile/library/v2/pkg/devfile/parser/data"
+	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
+	"github.com/devfile/library/v2/pkg/testingutil"
 	"github.com/golang/mock/gomock"
 	buildv1 "github.com/openshift/api/build/v1"
-	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
-
-	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
-
-	"github.com/devfile/library/v2/pkg/devfile/parser"
-	"github.com/devfile/library/v2/pkg/devfile/parser/data"
-	"github.com/devfile/library/v2/pkg/testingutil"
 )
 
 var isTrue bool = true

--- a/pkg/devfile/generator/utils_test.go
+++ b/pkg/devfile/generator/utils_test.go
@@ -1737,10 +1737,11 @@ func Test_containerOverridesHandler(t *testing.T) {
 		container *corev1.Container
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    *corev1.Container
-		wantErr bool
+		name      string
+		args      args
+		want      *corev1.Container
+		wantErr   bool
+		errString string
 	}{
 		{
 			name: "Override the resource requirements of the container component",
@@ -1815,8 +1816,9 @@ func Test_containerOverridesHandler(t *testing.T) {
 				},
 				container: getContainer(containerParams{Name: name, Image: image, Command: command, Args: argsSlice}),
 			},
-			want:    nil,
-			wantErr: true,
+			want:      nil,
+			wantErr:   true,
+			errString: "cannot use container-overrides to override container name, image, command, args, ports, volumeMounts, env",
 		},
 		{
 			name: "Invalid JSON for container-overrides",
@@ -1828,8 +1830,9 @@ func Test_containerOverridesHandler(t *testing.T) {
 				},
 				container: getContainer(containerParams{Name: name, Image: image, Command: command, Args: argsSlice}),
 			},
-			want:    nil,
-			wantErr: true,
+			want:      nil,
+			wantErr:   true,
+			errString: "failed to parse container-overrides attribute on component component3",
 		},
 	}
 	for _, tt := range tests {
@@ -1837,6 +1840,7 @@ func Test_containerOverridesHandler(t *testing.T) {
 			got, err := containerOverridesHandler(tt.args.comp, tt.args.container)
 			if tt.wantErr {
 				assert.NotNil(t, err, tt.name)
+				assert.Contains(t, err.Error(), tt.errString, "containerOverridesHandler() error does not match")
 			} else {
 				assert.Nil(t, err, tt.name)
 			}

--- a/pkg/devfile/generator/utils_test.go
+++ b/pkg/devfile/generator/utils_test.go
@@ -24,7 +24,6 @@ import (
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/api/v2/pkg/attributes"
 	"github.com/golang/mock/gomock"
-	"github.com/hashicorp/go-multierror"
 	buildv1 "github.com/openshift/api/build/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -33,9 +32,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 
+	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
+
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data"
-	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
 	"github.com/devfile/library/v2/pkg/testingutil"
 )
 
@@ -1809,7 +1809,7 @@ func Test_containerOverridesHandler(t *testing.T) {
 				comp: v1.Component{
 					Name: "component2",
 					Attributes: attributes.Attributes{
-						ContainerOverridesAttribute: apiextensionsv1.JSON{Raw: []byte("{\"name\": \"othername\",\"image\": \"quay.io/other/image\", \"command\": \"echo\", \"args\": [\"hello world\"], \"ports\": [{\"containerPort\": \"9090\"}], \"env\": [{\"name\":\"somename\", \"value\":\"somevalue\"}], \"volumeMounts\": [{\"name\":\"volume1\",\"mountPath\":\"/var/www\"}]}")}},
+						ContainerOverridesAttribute: apiextensionsv1.JSON{Raw: []byte("{\"name\": \"othername\",\"image\": \"quay.io/other/image\", \"command\": [\"echo\"], \"args\": [\"hello world\"], \"ports\": [{\"containerPort\":9090}], \"env\": [{\"name\":\"somename\", \"value\":\"somevalue\"}], \"volumeMounts\": [{\"name\":\"volume1\",\"mountPath\":\"/var/www\"}]}")}},
 				},
 				container: getContainer(containerParams{Name: name, Image: image, Command: command, Args: argsSlice}),
 			},

--- a/pkg/devfile/generator/utils_test.go
+++ b/pkg/devfile/generator/utils_test.go
@@ -1804,12 +1804,12 @@ func Test_containerOverridesHandler(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Should not Override the image of the container component",
+			name: "Should not override restricted fields of the container component",
 			args: args{
 				comp: v1.Component{
 					Name: "component2",
 					Attributes: attributes.Attributes{
-						ContainerOverridesAttribute: apiextensionsv1.JSON{Raw: []byte("{\"image\": \"quay.io/other/image\"}")}},
+						ContainerOverridesAttribute: apiextensionsv1.JSON{Raw: []byte("{\"name\": \"othername\",\"image\": \"quay.io/other/image\", \"command\": \"echo\", \"args\": [\"hello world\"], \"ports\": [{\"containerPort\": \"9090\"}], \"env\": [{\"name\":\"somename\", \"value\":\"somevalue\"}], \"volumeMounts\": [{\"name\":\"volume1\",\"mountPath\":\"/var/www\"}]}")}},
 				},
 				container: getContainer(containerParams{Name: name, Image: image, Command: command, Args: argsSlice}),
 			},


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Adds support for container-overrides attribute, as described in https://github.com/devfile/api/issues/920#issuecomment-1244059075.

The logic for this PR is motivated by https://github.com/devfile/devworkspace-operator/pull/967.

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
Fixes part of https://github.com/devfile/api/issues/936

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->
   Will work on docs once the PR is approved.

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
Override fields such as securityContext or resources of container by using `components[*].container.attributes` field.
Use the examples in https://github.com/devfile/api/issues/920#issue-1362465268.