### PR TITLE
Add support for "pod-overrides" attribute

### DIFF
--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -185,13 +185,12 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 		Containers:     deployParams.Containers,
 		Volumes:        deployParams.Volumes,
 	}
+
 	globalAttributes, err := devfileObj.Data.GetAttributes()
 	if err != nil {
 		return nil, err
 	}
-	components, err := devfileObj.Data.GetDevfileContainerComponents(common.DevfileOptions{
-		FilterByName: "",
-	})
+	components, err := devfileObj.Data.GetDevfileContainerComponents(common.DevfileOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -185,9 +185,22 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 		Containers:     deployParams.Containers,
 		Volumes:        deployParams.Volumes,
 	}
-
+	globalAttributes, err := devfileObj.Data.GetAttributes()
+	if err != nil {
+		return nil, err
+	}
+	components, err := devfileObj.Data.GetDevfileContainerComponents(common.DevfileOptions{
+		FilterByName: "",
+	})
+	if err != nil {
+		return nil, err
+	}
+	podTemplateSpec, err := getPodTemplateSpec(globalAttributes, components, podTemplateSpecParams)
+	if err != nil {
+		return nil, err
+	}
 	deploySpecParams := deploymentSpecParams{
-		PodTemplateSpec:   *getPodTemplateSpec(podTemplateSpecParams),
+		PodTemplateSpec:   *podTemplateSpec,
 		PodSelectorLabels: deployParams.PodSelectorLabels,
 		Replicas:          deployParams.Replicas,
 	}

--- a/pkg/devfile/generator/utils.go
+++ b/pkg/devfile/generator/utils.go
@@ -347,13 +347,13 @@ func getPodOverrides(globalAttributes attributes.Attributes, components []v1.Com
 		}
 		// Do not allow overriding containers or volumes
 		if override.Spec.Containers != nil {
-			return nil, fmt.Errorf("cannot use pod-overrides to override pod containers")
+			return nil, fmt.Errorf("cannot use %s to override pod containers", PodOverridesAttribute)
 		}
 		if override.Spec.InitContainers != nil {
-			return nil, fmt.Errorf("cannot use pod-overrides to override pod initContainers")
+			return nil, fmt.Errorf("cannot use %s to override pod initContainers", PodOverridesAttribute)
 		}
 		if override.Spec.Volumes != nil {
-			return nil, fmt.Errorf("cannot use pod-overrides to override pod volumes")
+			return nil, fmt.Errorf("cannot use %s to override pod volumes", PodOverridesAttribute)
 		}
 		patchData := globalAttributes[PodOverridesAttribute]
 		allOverrides = append(allOverrides, patchData)

--- a/pkg/devfile/generator/utils.go
+++ b/pkg/devfile/generator/utils.go
@@ -256,6 +256,7 @@ func getPodTemplateSpec(globalAttributes attributes.Attributes, components []v1.
 		if err != nil {
 			return nil, err
 		}
+		patchedPodTemplateSpec.ObjectMeta = podTemplateSpecParams.ObjectMeta
 		podTemplateSpec = patchedPodTemplateSpec
 	}
 

--- a/pkg/devfile/generator/utils_test.go
+++ b/pkg/devfile/generator/utils_test.go
@@ -1912,6 +1912,27 @@ func Test_applyPodOverrides(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Should override field as defined inside pod-overrides container level attribute",
+			args: args{
+				components: []v1.Component{
+					func() v1.Component {
+						container := devfileContainer
+						container.Attributes = attributes.Attributes{
+							PodOverridesAttribute: apiextensionsv1.JSON{Raw: []byte("{\"spec\": {\"schedulerName\": \"stork\"}}")},
+						}
+						return container
+					}(),
+				},
+				podTemplateSpec: &defaultPodSpec,
+			},
+			want: func() *corev1.PodTemplateSpec {
+				podSpec := defaultPodSpec
+				podSpec.Spec.SchedulerName = "stork"
+				return &podSpec
+			}(),
+			wantErr: false,
+		},
+		{
 			name: "Should override fields as defined inside pod-overrides attribute at devfile and container level",
 			args: args{
 				globalAttributes: attributes.Attributes{


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Adds support for pod-overrides attribute, as described in https://github.com/devfile/api/issues/920#issuecomment-1244059075.

The logic for this PR is motivated by https://github.com/devfile/devworkspace-operator/pull/967.
### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
Fixes part of https://github.com/devfile/api/issues/936
### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->
Will work on docs once the PR is approved.
- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
Override fields such as securityContext or resources of a pod by using `components[*].container.attributes` or `metadata.attributes` field.