### PR TITLE
Update ingress from extension to networking api

### DIFF
--- a/pkg/devfile/parser/reader.go
+++ b/pkg/devfile/parser/reader.go
@@ -29,7 +29,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 // YamlSrc specifies the src of the yaml in either Path, URL or Data format
@@ -48,7 +48,7 @@ type KubernetesResources struct {
 	Deployments []appsv1.Deployment
 	Services    []corev1.Service
 	Routes      []routev1.Route
-	Ingresses   []extensionsv1.Ingress
+	Ingresses   []networkingv1.Ingress
 	Others      []interface{}
 }
 
@@ -106,14 +106,14 @@ func ParseKubernetesYaml(values []interface{}) (KubernetesResources, error) {
 	var deployments []appsv1.Deployment
 	var services []corev1.Service
 	var routes []routev1.Route
-	var ingresses []extensionsv1.Ingress
+	var ingresses []networkingv1.Ingress
 	var otherResources []interface{}
 
 	for _, value := range values {
 		var deployment appsv1.Deployment
 		var service corev1.Service
 		var route routev1.Route
-		var ingress extensionsv1.Ingress
+		var ingress networkingv1.Ingress
 		var otherResource interface{}
 
 		byteData, err := k8yaml.Marshal(value)


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
updates the reader ingress api. Since ODC/HAS are not using Ingresses yet, its better to use the latest api https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
N/A

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
tests should pass