### PR TITLE
Fix GetDeployment function when Devfile SchemaVersion is less than 2.1.0

### DIFF
--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -17,6 +17,8 @@ package generator
 
 import (
 	"fmt"
+	"github.com/devfile/api/v2/pkg/attributes"
+	"github.com/devfile/library/v2/pkg/devfile/parser/data"
 
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
@@ -185,10 +187,14 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 		Containers:     deployParams.Containers,
 		Volumes:        deployParams.Volumes,
 	}
-
-	globalAttributes, err := devfileObj.Data.GetAttributes()
-	if err != nil {
-		return nil, err
+	var globalAttributes attributes.Attributes
+	// attributes is not supported in versions less than 2.0.0, so we skip it
+	if devfileObj.Data.GetSchemaVersion() > string(data.APISchemaVersion200) {
+		var err error
+		globalAttributes, err = devfileObj.Data.GetAttributes()
+		if err != nil {
+			return nil, err
+		}
 	}
 	components, err := devfileObj.Data.GetDevfileContainerComponents(common.DevfileOptions{})
 	if err != nil {

--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -17,6 +17,7 @@ package generator
 
 import (
 	"fmt"
+
 	"github.com/devfile/api/v2/pkg/attributes"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data"
 
@@ -188,7 +189,7 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 		Volumes:        deployParams.Volumes,
 	}
 	var globalAttributes attributes.Attributes
-	// attributes is not supported in versions less than 2.0.0, so we skip it
+	// attributes is not supported in versions less than 2.1.0, so we skip it
 	if devfileObj.Data.GetSchemaVersion() > string(data.APISchemaVersion200) {
 		var err error
 		globalAttributes, err = devfileObj.Data.GetAttributes()

--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -191,11 +191,9 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 	var globalAttributes attributes.Attributes
 	// attributes is not supported in versions less than 2.1.0, so we skip it
 	if devfileObj.Data.GetSchemaVersion() > string(data.APISchemaVersion200) {
-		var err error
-		globalAttributes, err = devfileObj.Data.GetAttributes()
-		if err != nil {
-			return nil, err
-		}
+		// the only time GetAttributes will return an error is if DevfileSchemaVersion is 2.0.0, a case we've already covered;
+		// so we'll skip checking for error here
+		globalAttributes, _ = devfileObj.Data.GetAttributes()
 	}
 	components, err := devfileObj.Data.GetDevfileContainerComponents(common.DevfileOptions{})
 	if err != nil {

--- a/pkg/devfile/generator/generators_test.go
+++ b/pkg/devfile/generator/generators_test.go
@@ -17,10 +17,11 @@ package generator
 
 import (
 	"fmt"
-	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"reflect"
 	"strings"
 	"testing"
+
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1081,6 +1082,7 @@ func TestGetDeployment(t *testing.T) {
 		expected            *appsv1.Deployment
 		attributes          attributes.Attributes
 		wantErr             bool
+		devObj              func(ctrl *gomock.Controller, containerComponents []v1.Component) parser.DevfileObj
 	}{
 		{
 			// Currently dedicatedPod can only filter out annotations
@@ -1248,26 +1250,97 @@ func TestGetDeployment(t *testing.T) {
 			expected: nil,
 			wantErr:  trueBool,
 		},
+		{
+			name: "skip getting global attributes for SchemaVersion less than 2.1.0",
+			containerComponents: []v1.Component{
+				testingutil.GenerateDummyContainerComponent("container1", nil, []v1.Endpoint{
+					{
+						Name:       "http-8080",
+						TargetPort: 8080,
+					},
+				}, nil, v1.Annotation{
+					Deployment: map[string]string{
+						"key1": "value1",
+					},
+				}, nil),
+				testingutil.GenerateDummyContainerComponent("container2", nil, nil, nil, v1.Annotation{
+					Deployment: map[string]string{
+						"key2": "value2",
+					},
+				}, nil),
+			},
+			deploymentParams: DeploymentParams{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"preserved-key": "preserved-value",
+					},
+				},
+				Containers: containers,
+			},
+			expected: &appsv1.Deployment{
+				ObjectMeta: objectMeta,
+				Spec: appsv1.DeploymentSpec{
+					Strategy: appsv1.DeploymentStrategy{
+						Type: appsv1.RecreateDeploymentStrategyType,
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: nil,
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: objectMeta,
+						Spec: corev1.PodSpec{
+							Containers: containers,
+						},
+					},
+				},
+			},
+			attributes: nil,
+			wantErr:    false,
+			devObj: func(ctrl *gomock.Controller, containerComponents []v1.Component) parser.DevfileObj {
+				mockDevfileData := data.NewMockDevfileData(ctrl)
+
+				options := common.DevfileOptions{
+					ComponentOptions: common.ComponentOptions{
+						ComponentType: v1.ContainerComponentType,
+					},
+				}
+				// set up the mock data
+				mockDevfileData.EXPECT().GetSchemaVersion().Return("2.0.0")
+				mockDevfileData.EXPECT().GetDevfileContainerComponents(common.DevfileOptions{}).Return(containerComponents, nil).AnyTimes()
+				mockDevfileData.EXPECT().GetComponents(options).Return(containerComponents, nil).AnyTimes()
+
+				devObj := parser.DevfileObj{
+					Data: mockDevfileData,
+				}
+				return devObj
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			mockDevfileData := data.NewMockDevfileData(ctrl)
+			var devObj parser.DevfileObj
+			if tt.devObj != nil {
+				devObj = tt.devObj(ctrl, tt.containerComponents)
+			} else {
+				mockDevfileData := data.NewMockDevfileData(ctrl)
 
-			options := common.DevfileOptions{
-				ComponentOptions: common.ComponentOptions{
-					ComponentType: v1.ContainerComponentType,
-				},
-			}
-			// set up the mock data
-			mockDevfileData.EXPECT().GetAttributes().Return(tt.attributes, nil).AnyTimes()
-			mockDevfileData.EXPECT().GetDevfileContainerComponents(common.DevfileOptions{}).Return(tt.containerComponents, nil).AnyTimes()
-			mockDevfileData.EXPECT().GetComponents(options).Return(tt.containerComponents, nil).AnyTimes()
+				options := common.DevfileOptions{
+					ComponentOptions: common.ComponentOptions{
+						ComponentType: v1.ContainerComponentType,
+					},
+				}
+				// set up the mock data
+				mockDevfileData.EXPECT().GetSchemaVersion().Return("2.1.0")
+				mockDevfileData.EXPECT().GetAttributes().Return(tt.attributes, nil).AnyTimes()
+				mockDevfileData.EXPECT().GetDevfileContainerComponents(common.DevfileOptions{}).Return(tt.containerComponents, nil).AnyTimes()
+				mockDevfileData.EXPECT().GetComponents(options).Return(tt.containerComponents, nil).AnyTimes()
 
-			devObj := parser.DevfileObj{
-				Data: mockDevfileData,
+				devObj = parser.DevfileObj{
+					Data: mockDevfileData,
+				}
 			}
 			deploy, err := GetDeployment(devObj, tt.deploymentParams)
 			// Checks for unexpected error cases

--- a/pkg/devfile/generator/utils.go
+++ b/pkg/devfile/generator/utils.go
@@ -250,8 +250,7 @@ func getPodTemplateSpec(globalAttributes attributes.Attributes, components []v1.
 			Volumes:        podTemplateSpecParams.Volumes,
 		},
 	}
-
-	if needsPodOverrides(globalAttributes, components) {
+	if len(globalAttributes) != 0 && needsPodOverrides(globalAttributes, components) {
 		patchedPodTemplateSpec, err := applyPodOverrides(globalAttributes, components, podTemplateSpec)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: Parthvi Vala <pvala@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
When `GetDeployment` is called for a Devfile schemaVersion less than 2.1.0. Currently it fails with error "top-level attributes is not supported in devfile schema version 2.0.0".

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
Use the following devfile for example:
<details>
<summary>devfile.yaml</summary>
```yaml
commands:
- exec:
    commandLine: npm install
    component: runtime
    group:
      isDefault: true
      kind: build
    workingDir: ${PROJECTS_ROOT}
  id: devbuild
- exec:
    commandLine: npm install
    component: runtime
    group:
      kind: build
    workingDir: ${PROJECTS_ROOT}
  id: build
- exec:
    commandLine: npm start
    component: runtime
    group:
      isDefault: true
      kind: run
    workingDir: ${PROJECTS_ROOT}
  id: devrun
- exec:
    commandLine: npm start
    component: runtime
    group:
      kind: run
    workingDir: ${PROJECTS_ROOT}
  id: run
components:
- container:
    endpoints:
    - name: 3000-tcp
      targetPort: 3000
    image: registry.access.redhat.com/ubi8/nodejs-12:1-36
    memoryLimit: 1024Mi
    mountSources: true
  name: runtime
metadata:
  language: nodejs
  name: vwcwtk
  projectType: nodejs
schemaVersion: 2.0.0
starterProjects:
- git:
    remotes:
      origin: https://github.com/odo-devfiles/nodejs-ex.git
  name: nodejs-starter
```
</details>

I reproduced this issue with odo. You can use `odo dev` with the Devfile and see the error.
I'll add the unit test once the changes have been approved.