### PR TITLE
Fix pod-overrides for container level

### DIFF
--- a/pkg/devfile/generator/utils.go
+++ b/pkg/devfile/generator/utils.go
@@ -250,7 +250,7 @@ func getPodTemplateSpec(globalAttributes attributes.Attributes, components []v1.
 			Volumes:        podTemplateSpecParams.Volumes,
 		},
 	}
-	if len(globalAttributes) != 0 && needsPodOverrides(globalAttributes, components) {
+	if needsPodOverrides(globalAttributes, components) {
 		patchedPodTemplateSpec, err := applyPodOverrides(globalAttributes, components, podTemplateSpec)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: Parthvi Vala <pvala@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR fixes a faulty behavior when pod-overrides is defined at container level.
### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [x] Documentation (https://github.com/devfile/devfile-web/pull/70)

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
<details>
<summary>1. Use the following Devfile:</summary>

```yaml
commands:
  - exec:
      commandLine: npm install
      component: runtime
      group:
        isDefault: true
        kind: build
      workingDir: ${PROJECT_SOURCE}
    id: install
  - exec:
      commandLine: npm start
      component: runtime
      group:
        isDefault: true
        kind: run
      workingDir: ${PROJECT_SOURCE}
    id: run
  - exec:
      commandLine: npm run debug
      component: runtime
      group:
        isDefault: true
        kind: debug
      workingDir: ${PROJECT_SOURCE}
    id: debug
  - exec:
      commandLine: npm test
      component: runtime
      group:
        isDefault: true
        kind: test
      workingDir: ${PROJECT_SOURCE}
    id: test
components:
  - container:
      args:
        - tail
        - -f
        - /dev/null
      endpoints:
        - name: http-node
          targetPort: 3000
        - exposure: none
          name: debug
          targetPort: 5858
      env:
        - name: DEBUG_PORT
          value: "5858"
      image: registry.access.redhat.com/ubi8/nodejs-16:latest
      memoryLimit: 1024Mi
      mountSources: true
    attributes:
      pod-overrides:
        spec:
          serviceAccountName: new-service-account
    name: runtime
  - kubernetes:
      inlined: |
        apiVersion: v1
        kind: ServiceAccount
        metadata:
          name: new-service-account
    name: service-account
metadata:
  description: Stack with Node.js 16
  displayName: Node.js Runtime
  icon: https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg
  language: JavaScript
  name: my-node-app
  projectType: Node.js
  tags:
    - Node.js
    - Express
    - ubi8
  version: 2.1.1
schemaVersion: 2.2.0
starterProjects:
  - git:
      remotes:
        origin: https://github.com/odo-devfiles/nodejs-ex.git
    name: nodejs-starter
```
</details>

2. `odo dev`
3. `kubectl get po my-node-app-xxx -ojsonpath='{.spec.serviceAccountName}'`; it should be `new-service-account`.
