### PR TITLE
Remove the error wrapping for reading K8s/OpenShift YAMLs

### DIFF
--- a/pkg/devfile/parser/parse.go
+++ b/pkg/devfile/parser/parse.go
@@ -161,7 +161,7 @@ func ParseDevfile(args ParserArgs) (d DevfileObj, err error) {
 		d.Ctx.SetConvertUriToInlined(true)
 		err = parseKubeResourceFromURI(d)
 		if err != nil {
-			return d, errors.Wrapf(err, "failed to parse kubernetes/openshift component from uri to inlined")
+			return d, err
 		}
 	}
 
@@ -608,7 +608,7 @@ func convertDevWorskapceTemplateToDevObj(dwTemplate v1.DevWorkspaceTemplate) (d 
 
 }
 
-//setDefaults sets the default values for nil boolean properties after the merging of devWorkspaceTemplateSpec is complete
+// setDefaults sets the default values for nil boolean properties after the merging of devWorkspaceTemplateSpec is complete
 func setDefaults(d DevfileObj) (err error) {
 
 	var devfileVersion string
@@ -709,13 +709,13 @@ func setDefaults(d DevfileObj) (err error) {
 	return nil
 }
 
-///setIsDefault sets the default value of CommandGroup.IsDefault if nil
+// setIsDefault sets the default value of CommandGroup.IsDefault if nil
 func setIsDefault(cmdGroup *v1.CommandGroup) {
 	val := cmdGroup.GetIsDefault()
 	cmdGroup.IsDefault = &val
 }
 
-//setEndpoints sets the default value of Endpoint.Secure if nil
+// setEndpoints sets the default value of Endpoint.Secure if nil
 func setEndpoints(endpoints []v1.Endpoint) {
 	for i := range endpoints {
 		val := endpoints[i].GetSecure()
@@ -723,7 +723,7 @@ func setEndpoints(endpoints []v1.Endpoint) {
 	}
 }
 
-//parseKubeResourceFromURI iterate through all kubernetes & openshift components, and parse from uri and update the content to inlined field in devfileObj
+// parseKubeResourceFromURI iterate through all kubernetes & openshift components, and parse from uri and update the content to inlined field in devfileObj
 func parseKubeResourceFromURI(devObj DevfileObj) error {
 	getKubeCompOptions := common.DevfileOptions{
 		ComponentOptions: common.ComponentOptions{
@@ -748,7 +748,7 @@ func parseKubeResourceFromURI(devObj DevfileObj) error {
 			/* #nosec G601 -- not an issue, kubeComp is de-referenced in sequence*/
 			err := convertK8sLikeCompUriToInlined(&kubeComp, devObj.Ctx)
 			if err != nil {
-				return errors.Wrapf(err, "failed to convert Kubernetes Uri to inlined for component '%s'", kubeComp.Name)
+				return errors.Wrapf(err, "failed to convert kubernetes uri to inlined for component '%s'", kubeComp.Name)
 			}
 			err = devObj.Data.UpdateComponent(kubeComp)
 			if err != nil {
@@ -761,7 +761,7 @@ func parseKubeResourceFromURI(devObj DevfileObj) error {
 			/* #nosec G601 -- not an issue, openshiftComp is de-referenced in sequence*/
 			err := convertK8sLikeCompUriToInlined(&openshiftComp, devObj.Ctx)
 			if err != nil {
-				return errors.Wrapf(err, "failed to convert Openshift Uri to inlined for component '%s'", openshiftComp.Name)
+				return errors.Wrapf(err, "failed to convert openshift uri to inlined for component '%s'", openshiftComp.Name)
 			}
 			err = devObj.Data.UpdateComponent(openshiftComp)
 			if err != nil {
@@ -772,7 +772,7 @@ func parseKubeResourceFromURI(devObj DevfileObj) error {
 	return nil
 }
 
-//convertK8sLikeCompUriToInlined read in kubernetes resources definition from uri and converts to kubernetest inlined field
+// convertK8sLikeCompUriToInlined read in kubernetes resources definition from uri and converts to kubernetest inlined field
 func convertK8sLikeCompUriToInlined(component *v1.Component, d devfileCtx.DevfileCtx) error {
 	var uri string
 	if component.Kubernetes != nil {
@@ -799,7 +799,7 @@ func convertK8sLikeCompUriToInlined(component *v1.Component, d devfileCtx.Devfil
 	return nil
 }
 
-//getKubernetesDefinitionFromUri read in kubernetes resources definition from uri and returns the raw content
+// getKubernetesDefinitionFromUri read in kubernetes resources definition from uri and returns the raw content
 func getKubernetesDefinitionFromUri(uri string, d devfileCtx.DevfileCtx) ([]byte, error) {
 	// validate URI
 	err := validation.ValidateURI(uri)
@@ -834,7 +834,7 @@ func getKubernetesDefinitionFromUri(uri string, d devfileCtx.DevfileCtx) ([]byte
 		params := util.HTTPRequestParams{URL: newUri}
 		data, err = util.DownloadInMemory(params)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error getting kubernetes resources definition info from url '%s'", newUri)
+			return nil, errors.Wrapf(err, "error getting kubernetes resources definition information")
 		}
 	}
 	return data, nil


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Removes the excessive error wrapping

For example, this is what we see in HAS:
```
Status:
  Conditions:
    Last Transition Time:  2023-02-16T21:49:29Z
    Message:               Component create failed: failed to parse kubernetes/openshift component from uri to inlined: failed to convert Kubernetes Uri to inlined for component 'kubernetes-only-deploy': error getting kubernetes resources definition info from url 'https://raw.githubusercontent.com/maysunfaisal/devfileexample/main/case4/nodeploy.yaml': failed to retrieve https://raw.githubusercontent.com/maysunfaisal/devfileexample/main/case4/nodeploy.yaml, 404: Not Found
    Reason:                Error
    Status:                False
    Type:                  Created
```

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
N/A

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
