### PR TITLE
Add DevfileOptions to GetPodTemplateSpec

### DIFF
--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Red Hat, Inc.
+// Copyright 2022-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -238,7 +238,7 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 // PodTemplateParams is a struct that contains the required data to create a podtemplatespec object
 type PodTemplateParams struct {
 	ObjectMeta metav1.ObjectMeta
-	options    common.DevfileOptions
+	Options    common.DevfileOptions
 	// PodSecurityAdmissionPolicy is the policy to be respected by the created pod
 	// The pod will be patched, if necessary, to respect the policies
 	PodSecurityAdmissionPolicy psaapi.Policy
@@ -250,9 +250,9 @@ type PodTemplateParams struct {
 // - gets the init container for every preStart devfile event
 // - patches the pod template and containers to satisfy PodSecurityAdmissionPolicy
 // - patches the pod template and containers to apply pod and container overrides
-// The containers included in the podTemplateSpec can be filtered using podTemplateParams.options
+// The containers included in the podTemplateSpec can be filtered using podTemplateParams.Options
 func GetPodTemplateSpec(devfileObj parser.DevfileObj, podTemplateParams PodTemplateParams) (*corev1.PodTemplateSpec, error) {
-	containers, err := GetContainers(devfileObj, podTemplateParams.options)
+	containers, err := GetContainers(devfileObj, podTemplateParams.Options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devfile/generator/generators.go
+++ b/pkg/devfile/generator/generators.go
@@ -238,6 +238,7 @@ func GetDeployment(devfileObj parser.DevfileObj, deployParams DeploymentParams) 
 // PodTemplateParams is a struct that contains the required data to create a podtemplatespec object
 type PodTemplateParams struct {
 	ObjectMeta metav1.ObjectMeta
+	options    common.DevfileOptions
 	// PodSecurityAdmissionPolicy is the policy to be respected by the created pod
 	// The pod will be patched, if necessary, to respect the policies
 	PodSecurityAdmissionPolicy psaapi.Policy
@@ -249,8 +250,9 @@ type PodTemplateParams struct {
 // - gets the init container for every preStart devfile event
 // - patches the pod template and containers to satisfy PodSecurityAdmissionPolicy
 // - patches the pod template and containers to apply pod and container overrides
+// The containers included in the podTemplateSpec can be filtered using podTemplateParams.options
 func GetPodTemplateSpec(devfileObj parser.DevfileObj, podTemplateParams PodTemplateParams) (*corev1.PodTemplateSpec, error) {
-	containers, err := GetContainers(devfileObj, common.DevfileOptions{})
+	containers, err := GetContainers(devfileObj, podTemplateParams.options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?:

The PR adds the ability to filter the containers included in the `generator.PodTemplateSpec()` when calling GetPodTemplateSpec. This is equivalent to filtering when calling `GetContainers()`


### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
