### PR TITLE
fix the invalid kube yaml causing panic issue

### DIFF
--- a/pkg/devfile/parser/reader.go
+++ b/pkg/devfile/parser/reader.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Red Hat, Inc.
+// Copyright 2022-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -121,7 +121,12 @@ func ParseKubernetesYaml(values []interface{}) (KubernetesResources, error) {
 			return KubernetesResources{}, err
 		}
 
-		kubernetesMap := value.(map[string]interface{})
+		// kubernetesMap := value.(map[string]interface{})
+		var kubernetesMap map[string]interface{}
+		err = k8yaml.Unmarshal(byteData, &kubernetesMap)
+		if err != nil {
+			return KubernetesResources{}, err
+		}
 		kind := kubernetesMap["kind"]
 
 		switch kind {


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR updates  the kubeyaml parser to use unmarshal to ensure the kube yaml is in the expected format. to avoid the panic when trying to convert an `interface{}` into a 'map[string]interface {}'

```
panic: interface conversion: interface {} is string, not map[string]interface {} [recovered]
	panic: interface conversion: interface {} is string, not map[string]interface {}
```

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
for has bug: https://issues.redhat.com/browse/RHTAPBUGS-113

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
