### PR TITLE
Gate downloading of git resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ The function documentation can be accessed via [pkg.go.dev](https://pkg.go.dev/g
    ...
    ```
 
+10. By default, the library downloads the Git repository resources associated with the Git URL that is mentioned in a devfile uri field. To turn off the download, pass in the `DownloadGitResources` property in the parser argument
+   ```go
+   downloadGitResources := false
+   parserArgs := parser.ParserArgs{
+		DownloadGitResources:               &downloadGitResources,
+   }
+   ```
+
 ## Projects using devfile/library
 
 The following projects are consuming this library as a Golang dependency


### PR DESCRIPTION
### What does this PR do?:
Gates the logic for downloading git resources. Clients od devfile/library may be running behind a proxy, so we cannot invoke git operations as they may fail

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
Fixes https://github.com/devfile/api/issues/1176

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
