### PR TITLE
Update github actions to use NodeJS 16

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           persist-credentials: false
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: 1.19
       - name: Run tests
         run: make test
       - name: Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
 
     - name: Setup Go environment
-      uses: actions/setup-go@v2.1.3
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version: 1.19
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
     - name: Check go mod status
       run: |
@@ -75,4 +75,4 @@ jobs:
         sarif_file: gosec.sarif
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2.1.0
+      uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4


### PR DESCRIPTION
### What does this PR do?:

This PR updates all deprecated github actions using NodeJS 12 in order to use NodeJS 16. The list of actions updated are:

- `actions/checkout@v2` > `actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3`
- `actions/setup-go@v2` > `actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0`
- `codecov/codecov-action@2.1.0` > `codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4`

### Which issue(s) this PR fixes:

Fixes https://github.com/devfile/api/issues/1225

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [x] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [x] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [x] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
