### PR TITLE
Add ability to use mock without passing in arguments

### DIFF
--- a/pkg/devfile/parser/util/mock.go
+++ b/pkg/devfile/parser/util/mock.go
@@ -49,9 +49,20 @@ func (gc MockDevfileUtilsClient) DownloadInMemory(params util.HTTPRequestParams)
 
 	var mockGitUrl util.MockGitUrl
 
-	if util.IsGitProviderRepo(gc.MockGitURL.Host) {
-		mockGitUrl = gc.MockGitURL
-		mockGitUrl.Token = gc.GitTestToken
+	if gc.MockGitURL.Host != "" {
+		if util.IsGitProviderRepo(gc.MockGitURL.Host) {
+			mockGitUrl = gc.MockGitURL
+			mockGitUrl.Token = gc.GitTestToken
+		}
+	} else if params.URL != "" {
+		// Not all clients have the ability to pass in mock data
+		// So we should be adaptable and use the function params
+		// and mock the output
+		if util.IsGitProviderRepo(params.URL) {
+			gc.MockGitURL.Host = params.URL
+			mockGitUrl = gc.MockGitURL
+			mockGitUrl.Token = params.Token
+		}
 	}
 
 	return mockGitUrl.DownloadInMemoryWithClient(params, httpClient, gc.DownloadOptions)

--- a/pkg/devfile/parser/util/utils_test.go
+++ b/pkg/devfile/parser/util/utils_test.go
@@ -106,6 +106,12 @@ func TestDownloadInMemoryClient(t *testing.T) {
 			url:     "https://github.com/devfile/library/blob/main/devfile.yaml",
 			wantErr: "failed to retrieve https://github.com/devfile/library/blob/main/devfile.yaml",
 		},
+		{
+			name:   "Case 9: Input github url is valid with a mock client, dont use mock data during invocation",
+			client: MockDevfileUtilsClient{},
+			url:    "https://raw.githubusercontent.com/maysunfaisal/OK/main/OK.txt",
+			want:   []byte{79, 75},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/devfile/parser/util/utils_test.go
+++ b/pkg/devfile/parser/util/utils_test.go
@@ -89,8 +89,8 @@ func TestDownloadInMemoryClient(t *testing.T) {
 			wantErr: fmt.Sprintf(downloadErr, "https://"+RawGitHubHost+"/devfile/library/main/devfile.yaml"),
 		},
 		{
-			name:   "Case 6: Input url is valid with a mock client",
-			client: MockDevfileUtilsClient{MockGitURL: util.MockGitUrl{Host: server.URL}, DownloadOptions: util.MockDownloadOptions{MockFile: "OK"}},
+			name:   "Case 6: Input url is valid with a mock client, dont use mock data during invocation",
+			client: MockDevfileUtilsClient{},
 			url:    server.URL,
 			want:   []byte{79, 75},
 		},

--- a/pkg/devfile/parser/util/utils_test.go
+++ b/pkg/devfile/parser/util/utils_test.go
@@ -90,8 +90,8 @@ func TestDownloadInMemoryClient(t *testing.T) {
 		},
 		{
 			name:   "Case 6: Input url is valid with a mock client",
-			client: MockDevfileUtilsClient{MockGitURL: util.MockGitUrl{Host: "https://github.com/devfile/library/blob/main/devfile.yaml"}, DownloadOptions: util.MockDownloadOptions{MockFile: "OK"}},
-			url:    "https://github.com/devfile/library/blob/main/devfile.yaml",
+			client: MockDevfileUtilsClient{MockGitURL: util.MockGitUrl{Host: server.URL}, DownloadOptions: util.MockDownloadOptions{MockFile: "OK"}},
+			url:    server.URL,
 			want:   []byte{79, 75},
 		},
 		{

--- a/pkg/util/mock.go
+++ b/pkg/util/mock.go
@@ -238,7 +238,7 @@ CMD [ "waitress-serve", "--port=8081", "app:app"]
 
 func (m MockGitUrl) DownloadInMemoryWithClient(params HTTPRequestParams, httpClient HTTPClient, options MockDownloadOptions) ([]byte, error) {
 
-	if m.GetToken() == "valid-token" || m.GetToken() == "" {
+	if m.GetToken() == "valid-token" {
 		switch {
 		case options.MockDevfile:
 			return []byte(mockDevfile), nil
@@ -249,6 +249,9 @@ func (m MockGitUrl) DownloadInMemoryWithClient(params HTTPRequestParams, httpCli
 		default:
 			return []byte(mockDevfile), nil
 		}
+	} else if m.GetToken() == "" {
+		// if no token is provided, assume normal operation
+		return DownloadInMemory(params)
 	}
 
 	return nil, fmt.Errorf("failed to retrieve %s", params.URL)


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
- Adds the ability to use mock implementation without passing in mock data. Sometimes the client like HAS doesn't have the ability to pass in mock argument information always
- If no token is passed, dont mock output

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

<!-- 
- Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
- Check each criteria if:
  - There is a separate tracking issue. Add the issue link under the criteria
  **or**
  - test/doc updates are made as part of this PR
-  If unchecked, explain why it's not needed 
-->


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
tests should pass