### PR TITLE
Introduce err code for user error in devfile

### DIFF
--- a/pkg/devfile/parse.go
+++ b/pkg/devfile/parse.go
@@ -18,6 +18,7 @@ package devfile
 import (
 	"github.com/devfile/api/v2/pkg/validation/variables"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
+	errPkg "github.com/devfile/library/v2/pkg/devfile/parser/errors"
 	"github.com/devfile/library/v2/pkg/devfile/validate"
 )
 
@@ -121,7 +122,7 @@ func ParseDevfileAndValidate(args parser.ParserArgs) (d parser.DevfileObj, varWa
 	// generic validation on devfile content
 	err = validate.ValidateDevfileData(d.Data)
 	if err != nil {
-		return d, varWarning, err
+		return d, varWarning, &errPkg.NonCompliantDevfile{Err: err.Error()}
 	}
 
 	return d, varWarning, err

--- a/pkg/devfile/parser/context/apiVersion.go
+++ b/pkg/devfile/parser/context/apiVersion.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"github.com/devfile/library/v2/pkg/devfile/parser/data"
-	"github.com/pkg/errors"
+	errPkg "github.com/devfile/library/v2/pkg/devfile/parser/errors"
 	"k8s.io/klog"
 )
 
@@ -32,7 +32,7 @@ func (d *DevfileCtx) SetDevfileAPIVersion() error {
 	var r map[string]interface{}
 	err := json.Unmarshal(d.rawContent, &r)
 	if err != nil {
-		return errors.Wrapf(err, "failed to decode devfile json")
+		return &errPkg.NonCompliantDevfile{Err: err.Error()}
 	}
 
 	// Get "schemaVersion" value from map for devfile V2
@@ -47,10 +47,10 @@ func (d *DevfileCtx) SetDevfileAPIVersion() error {
 	if okSchema {
 		// SchemaVersion cannot be empty
 		if schemaVersion.(string) == "" {
-			return fmt.Errorf("schemaVersion in devfile: %s cannot be empty", devfilePath)
+			return &errPkg.NonCompliantDevfile{Err: fmt.Sprintf("schemaVersion in devfile: %s cannot be empty", devfilePath)}
 		}
 	} else {
-		return fmt.Errorf("schemaVersion not present in devfile: %s", devfilePath)
+		return &errPkg.NonCompliantDevfile{Err: fmt.Sprintf("schemaVersion not present in devfile: %s", devfilePath)}
 	}
 
 	// Successful

--- a/pkg/devfile/parser/context/apiVersion_test.go
+++ b/pkg/devfile/parser/context/apiVersion_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	errPkg "github.com/devfile/library/v2/pkg/devfile/parser/errors"
 )
 
 func TestSetDevfileAPIVersion(t *testing.T) {
@@ -56,13 +58,13 @@ func TestSetDevfileAPIVersion(t *testing.T) {
 			name:       "schemaVersion not present",
 			devfileCtx: DevfileCtx{rawContent: []byte(emptyJson), absPath: devfilePath},
 			want:       "",
-			wantErr:    fmt.Errorf("schemaVersion not present in devfile: %s", devfilePath),
+			wantErr:    &errPkg.NonCompliantDevfile{Err: fmt.Sprintf("schemaVersion not present in devfile: %s", devfilePath)},
 		},
 		{
 			name:       "schemaVersion empty",
 			devfileCtx: DevfileCtx{rawContent: []byte(emptySchemaVersionJson), url: devfileURL},
 			want:       "",
-			wantErr:    fmt.Errorf("schemaVersion in devfile: %s cannot be empty", devfileURL),
+			wantErr:    &errPkg.NonCompliantDevfile{Err: fmt.Sprintf("schemaVersion in devfile: %s cannot be empty", devfileURL)},
 		},
 	}
 

--- a/pkg/devfile/parser/context/apiVersion_test.go
+++ b/pkg/devfile/parser/context/apiVersion_test.go
@@ -31,6 +31,7 @@ func TestSetDevfileAPIVersion(t *testing.T) {
 		concreteSchema         = `{"schemaVersion": "2.2.0-latest"}`
 		emptyJson              = "{}"
 		emptySchemaVersionJson = `{"schemaVersion": ""}`
+		badJson                = `{"name": "Joe", "age": null]`
 		devfilePath            = "/testpath/devfile.yaml"
 		devfileURL             = "http://server/devfile.yaml"
 	)
@@ -65,6 +66,12 @@ func TestSetDevfileAPIVersion(t *testing.T) {
 			devfileCtx: DevfileCtx{rawContent: []byte(emptySchemaVersionJson), url: devfileURL},
 			want:       "",
 			wantErr:    &errPkg.NonCompliantDevfile{Err: fmt.Sprintf("schemaVersion in devfile: %s cannot be empty", devfileURL)},
+		},
+		{
+			name:       "unmarshal error",
+			devfileCtx: DevfileCtx{rawContent: []byte(badJson), url: devfileURL},
+			want:       "",
+			wantErr:    &errPkg.NonCompliantDevfile{Err: "invalid character ']' after object key:value pair"},
 		},
 	}
 

--- a/pkg/devfile/parser/context/content.go
+++ b/pkg/devfile/parser/context/content.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"unicode"
 
+	errPkg "github.com/devfile/library/v2/pkg/devfile/parser/errors"
 	parserUtil "github.com/devfile/library/v2/pkg/devfile/parser/util"
 	"github.com/devfile/library/v2/pkg/util"
 	"github.com/pkg/errors"
@@ -42,7 +43,7 @@ func YAMLToJSON(data []byte) ([]byte, error) {
 	// Is YAML, convert to JSON
 	data, err := yaml.YAMLToJSON(data)
 	if err != nil {
-		return data, errors.Wrapf(err, "failed to convert devfile yaml to json")
+		return data, &errPkg.NonCompliantDevfile{Err: err.Error()}
 	}
 
 	// Successful

--- a/pkg/devfile/parser/context/context_test.go
+++ b/pkg/devfile/parser/context/context_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestPopulateFromBytes(t *testing.T) {
-	failedToConvertYamlErr := "failed to convert devfile yaml to json: yaml: mapping values are not allowed in this context"
+	failedToConvertYamlErr := "mapping values are not allowed in this context"
 
 	tests := []struct {
 		name        string

--- a/pkg/devfile/parser/context/schema.go
+++ b/pkg/devfile/parser/context/schema.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/devfile/library/v2/pkg/devfile/parser/data"
+	errPkg "github.com/devfile/library/v2/pkg/devfile/parser/errors"
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 	"k8s.io/klog"
@@ -30,7 +31,7 @@ func (d *DevfileCtx) SetDevfileJSONSchema() error {
 	// Check if json schema is present for the given apiVersion
 	jsonSchema, err := data.GetDevfileJSONSchema(d.apiVersion)
 	if err != nil {
-		return err
+		return &errPkg.NonCompliantDevfile{Err: err.Error()}
 	}
 	d.jsonSchema = jsonSchema
 	return nil
@@ -54,7 +55,7 @@ func (d *DevfileCtx) ValidateDevfileSchema() error {
 		for _, desc := range result.Errors() {
 			errMsg = errMsg + fmt.Sprintf("- %s\n", desc)
 		}
-		return fmt.Errorf(errMsg)
+		return &errPkg.NonCompliantDevfile{Err: errMsg}
 	}
 
 	// Sucessful

--- a/pkg/devfile/parser/errors/errors.go
+++ b/pkg/devfile/parser/errors/errors.go
@@ -1,0 +1,31 @@
+//
+// Copyright 2024 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import "fmt"
+
+// NonCompliantDevfile returns an error if devfile parsing failed due to Non-Compliant Devfile
+type NonCompliantDevfile struct {
+	Err string
+}
+
+func (e *NonCompliantDevfile) Error() string {
+	errMsg := "error parsing devfile because of non-compliant data"
+	if e.Err != "" {
+		errMsg = fmt.Sprintf("%s due to %v", errMsg, e.Err)
+	}
+	return errMsg
+}

--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -3102,8 +3102,8 @@ func Test_parseParentAndPlugin_RecursivelyReference(t *testing.T) {
 		expectedErr := fmt.Sprintf("devfile has an cycle in references: main devfile -> uri: %s%s -> name: %s, namespace: %s -> uri: %s%s -> uri: %s%s", httpPrefix, uri1, name, namespace,
 			httpPrefix, uri2, httpPrefix, uri1)
 		// Unexpected error
-		if err == nil || !reflect.DeepEqual(expectedErr, err.Error()) {
-			t.Errorf("Test_parseParentAndPlugin_RecursivelyReference() unexpected error: %v", err)
+		if err == nil || !strings.Contains(err.Error(), expectedErr) {
+			t.Errorf("Test_parseParentAndPlugin_RecursivelyReference() error did not match: %v", err)
 
 			return
 		}

--- a/pkg/devfile/parser/reader.go
+++ b/pkg/devfile/parser/reader.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 
+	errPkg "github.com/devfile/library/v2/pkg/devfile/parser/errors"
 	parserUtil "github.com/devfile/library/v2/pkg/devfile/parser/util"
 	"github.com/devfile/library/v2/pkg/util"
 	"github.com/pkg/errors"
@@ -132,7 +133,7 @@ func ParseKubernetesYaml(values []interface{}) (KubernetesResources, error) {
 		var kubernetesMap map[string]interface{}
 		err = k8yaml.Unmarshal(byteData, &kubernetesMap)
 		if err != nil {
-			return KubernetesResources{}, err
+			return KubernetesResources{}, &errPkg.NonCompliantDevfile{Err: err.Error()}
 		}
 		kind := kubernetesMap["kind"]
 
@@ -155,7 +156,7 @@ func ParseKubernetesYaml(values []interface{}) (KubernetesResources, error) {
 		}
 
 		if err != nil {
-			return KubernetesResources{}, err
+			return KubernetesResources{}, &errPkg.NonCompliantDevfile{Err: err.Error()}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
- Introduces err codes for user errors in devfile, so this helps devfile/library consumers with prometheus metrics
- remove unnecessary error wrapping

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
Partially https://issues.redhat.com/browse/DEVHAS-580

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

<!-- 
- Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
- Check each criteria if:
  - There is a separate tracking issue. Add the issue link under the criteria
  **or**
  - test/doc updates are made as part of this PR
-  If unchecked, explain why it's not needed 
-->


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
tests should pass