### PR TITLE
Add Functionality For Multiple Devfile Name Variations

### DIFF
--- a/pkg/devfile/parser/util/mock.go
+++ b/pkg/devfile/parser/util/mock.go
@@ -19,9 +19,13 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/devfile/library/v2/pkg/util"
+)
+
+// Default filenames for create devfile to be used in mocks
+const (
+	OutputDevfileYamlPath = "devfile.yaml"
 )
 
 type MockDevfileUtilsClient struct {
@@ -109,7 +113,7 @@ func (gc MockDevfileUtilsClient) DownloadGitRepoResources(url string, destDir st
 		mockGitUrl := gc.MockGitURL
 		mockGitUrl.Token = gc.GitTestToken
 
-		if !mockGitUrl.IsFile || mockGitUrl.Revision == "" || !strings.Contains(mockGitUrl.Path, OutputDevfileYamlPath) {
+		if !mockGitUrl.IsFile || mockGitUrl.Revision == "" || !ValidateDevfileExistence((mockGitUrl.Path)) {
 			return fmt.Errorf("error getting devfile from url: failed to retrieve %s", url+"/"+mockGitUrl.Path)
 		}
 

--- a/pkg/devfile/parser/util/utils.go
+++ b/pkg/devfile/parser/util/utils.go
@@ -25,10 +25,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-// Default filenames for create devfile
-const (
-	OutputDevfileYamlPath = "devfile.yaml"
-)
+// Contains common naming conventions for devfiles to look for when downloading resources
+var DevfilePossibilities = [...]string{"devfile.yaml", "devfile.yml", ".devfile.yaml", ".devfile.yml"}
 
 type DevfileUtilsClient struct {
 }
@@ -52,7 +50,7 @@ func (c DevfileUtilsClient) DownloadGitRepoResources(url string, destDir string,
 			return err
 		}
 
-		if !gitUrl.IsFile || gitUrl.Revision == "" || !strings.Contains(gitUrl.Path, OutputDevfileYamlPath) {
+		if !gitUrl.IsFile || gitUrl.Revision == "" || !ValidateDevfileExistence((gitUrl.Path)) {
 			return fmt.Errorf("error getting devfile from url: failed to retrieve %s", url)
 		}
 
@@ -87,4 +85,14 @@ func (c DevfileUtilsClient) DownloadGitRepoResources(url string, destDir string,
 	}
 
 	return nil
+}
+
+// ValidateDevfileExistence verifies if any of the naming possibilities for devfile are present in the url path
+func ValidateDevfileExistence(path string) bool {
+	for _, devfile := range DevfilePossibilities {
+		if strings.Contains(path, devfile) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/devfile/parser/util/utils.go
+++ b/pkg/devfile/parser/util/utils.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Contains common naming conventions for devfiles to look for when downloading resources
-var DevfilePossibilities = [...]string{"devfile.yaml", "devfile.yml", ".devfile.yaml", ".devfile.yml"}
+var DevfilePossibilities = [...]string{"devfile.yaml", ".devfile.yaml", "devfile.yml", ".devfile.yml"}
 
 type DevfileUtilsClient struct {
 }

--- a/pkg/devfile/parser/util/utils_test.go
+++ b/pkg/devfile/parser/util/utils_test.go
@@ -147,3 +147,51 @@ func TestDownloadInMemoryClient(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDevfileExistence(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		url           string
+		wantErr       bool
+		expectedValue bool
+	}{
+		{
+			name:          "recognizes devfile.yaml",
+			url:           "https://dummyurlpath/devfile/registry/main/stacks/python/3.0.0/devfile.yaml",
+			wantErr:       false,
+			expectedValue: true,
+		},
+		{
+			name:          "recognizes devfile.yml",
+			url:           "https://dummyurlpath/devfile/registry/main/stacks/python/3.0.0/devfile.yml",
+			wantErr:       false,
+			expectedValue: true,
+		},
+		{
+			name:          "recognizes .devfile.yaml",
+			url:           "https://dummyurlpath/devfile/registry/main/stacks/python/3.0.0/.devfile.yaml",
+			wantErr:       false,
+			expectedValue: true,
+		},
+		{
+			name:          "recognizes .devfile.yml",
+			url:           "https://dummyurlpath/devfile/registry/main/stacks/python/3.0.0/.devfile.yml",
+			wantErr:       false,
+			expectedValue: true,
+		},
+		{
+			name:          "no valid devfile in path",
+			url:           "https://dummyurlpath/devfile/registry/main/stacks/python/3.0.0/deploy.yaml",
+			wantErr:       true,
+			expectedValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := ValidateDevfileExistence(tt.url)
+			assert.EqualValues(t, tt.expectedValue, res, "expected res = %t, got %t", tt.expectedValue, res)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR updates the `DownloadGitRepoResources` function to allow for different naming schemes for devfiles to be supported. Before the change only `devfile.yaml` was being recognized. This PR adds support for `devfile.yaml`, `devfile.yml`, `.devfile.yaml` and `.devfile.yml`.  In addition to this it allows for more naming schemes to be added in the future.

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
fixes https://github.com/devfile/api/issues/1362

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

<!-- 
- Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
- Check each criteria if:
  - There is a separate tracking issue. Add the issue link under the criteria
  **or**
  - test/doc updates are made as part of this PR
-  If unchecked, explain why it's not needed 
-->


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
Running `make test` should pass with the addition of the new tests for the devfile validation.