### PR TITLE
Update schema version to 2.2.2 for nodejs test child devfiles

### DIFF
--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -46,7 +46,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const schemaVersion = string(data.APISchemaVersion220)
+const schemaVersion = string(data.APISchemaVersion222)
 
 var isTrue bool = true
 var isFalse bool = false
@@ -3275,7 +3275,7 @@ type setFields struct {
 func Test_ParseDevfileParentFromData(t *testing.T) {
 
 	//mainDevfile is based on the nodejs basic sample which has a parent reference to the nodejs stack: https://registry.devfile.io/devfiles/nodejs
-	mainDevfile := `schemaVersion: 2.2.0
+	mainDevfile := `schemaVersion: 2.2.2
 metadata:
   name: nodejs
   version: 2.1.1
@@ -4166,7 +4166,7 @@ func Test_parseFromURI(t *testing.T) {
 		},
 	}
 	rawContent := `
-	schemaVersion: 2.1.0
+	schemaVersion: 2.2.2
 	metadata:
 	 name: devfile
 	 version: 2.0.0
@@ -4317,7 +4317,7 @@ func Test_parseFromURI_GitProviders(t *testing.T) {
 		invalidRevision = "invalid-revision"
 	)
 
-	minimalDevfileContent := fmt.Sprintf("schemaVersion: 2.2.0\nmetadata:\n  name: devfile")
+	minimalDevfileContent := fmt.Sprintf("schemaVersion: 2.2.2\nmetadata:\n  name: devfile")
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		_, err := rw.Write([]byte(minimalDevfileContent))
 		if err != nil {

--- a/tests/v2/devfiles/samples/Test_Parent_RegistryURL.yaml
+++ b/tests/v2/devfiles/samples/Test_Parent_RegistryURL.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 parent:
   id: nodejs
   registryUrl: "https://registry.stage.devfile.io"


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Fixes mock child devfiles of the `nodejs` stack by bumping the schema version to `2.2.2`.

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->

fixes devfile/api#1589

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

<!-- 
- Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
- Check each criteria if:
  - There is a separate tracking issue. Add the issue link under the criteria
  **or**
  - test/doc updates are made as part of this PR
-  If unchecked, explain why it's not needed 
-->


- [X] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [X] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:

```
make test
```
