### PR TITLE
Fix parent version on test devfile

### DIFF
--- a/tests/v2/devfiles/samples/Test_Parent_RegistryURL.yaml
+++ b/tests/v2/devfiles/samples/Test_Parent_RegistryURL.yaml
@@ -2,6 +2,7 @@ schemaVersion: 2.2.2
 parent:
   id: nodejs
   registryUrl: "https://registry.stage.devfile.io"
+  version: 2.2.0
   commands:
   - id: run
     exec:

--- a/tests/v2/devfiles/samples/Test_Parent_RegistryURL.yaml
+++ b/tests/v2/devfiles/samples/Test_Parent_RegistryURL.yaml
@@ -2,7 +2,7 @@ schemaVersion: 2.2.2
 parent:
   id: nodejs
   registryUrl: "https://registry.stage.devfile.io"
-  version: 2.2.0
+  version: 2.2.1
   commands:
   - id: run
     exec:


### PR DESCRIPTION
### What does this PR do?:
The `Test_Parent_RegistryURL.yaml` consumes the latest parent version of `nodejs`. As a result any breaking changes will impact the library's tests. This PR simply fixes the version to `2.2.1` (current latest) so the test related to this file remain unimpacted by any changes of the `devfile/registry)

### Which issue(s) this PR fixes:

N/A

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

<!-- 
- Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
- Check each criteria if:
  - There is a separate tracking issue. Add the issue link under the criteria
  **or**
  - test/doc updates are made as part of this PR
-  If unchecked, explain why it's not needed 
-->


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [ ] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:
