### PR TITLE
Add ubuntu server bypass error case for invalid registry urls

### DIFF
--- a/pkg/devfile/parser/parse_test.go
+++ b/pkg/devfile/parser/parse_test.go
@@ -23,9 +23,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -4704,6 +4706,34 @@ func Test_parseFromRegistry(t *testing.T) {
 	invalidRegistryURLErr := "Get .* dial tcp: lookup http: .*"
 	resourceDownloadErr := "failed to pull stack from registry .*"
 	badDevfileErr := "error parsing devfile because of non-compliant data"
+
+	// set invalidRegistryURLErr to expect server misbehaving
+	// if distribution is Ubuntu Server
+	if runtime.GOOS == "linux" {
+		cmd := exec.Command("lsb_release", "-a")
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		if err := cmd.Run(); err != nil {
+			t.Errorf("Test_parseFromRegistry() unexpected error while fetching distribution: %v", stderr.String())
+			return
+		}
+
+		lsbrelease := stdout.String()
+		if strings.Contains(lsbrelease, "Ubuntu") {
+			cmd := exec.Command("dpkg", "-l", "ubuntu-desktop")
+			cmd.Stderr = &stderr
+
+			// This command will fail if Ubuntu Server
+			if err := cmd.Run(); err != nil && !strings.Contains(stderr.String(), "dpkg-query: no packages found matching ubuntu-desktop") {
+				t.Errorf("Test_parseFromRegistry() unexpected error while fetching distribution: %v", stderr.String())
+				return
+			} else if err != nil {
+				invalidRegistryURLErr += "|Get .* dial tcp: lookup http on .*: server misbehaving"
+			}
+		}
+	}
 
 	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var data []byte


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Adds a bypass error case to expect `Get "http://http//invalid.com/devfiles/notexist/": dial tcp: lookup http on 127.0.0.53:53: server misbehaving` for invalid registry urls in Ubuntu Server instances, which are the instances known to give this error for invalid urls when using `Go 1.21`.

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->

fixes devfile/api#1588

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened and linked to this PR, if they are not in the PR scope due to various constraints.

<!-- 
- Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
- Check each criteria if:
  - There is a separate tracking issue. Add the issue link under the criteria
  **or**
  - test/doc updates are made as part of this PR
-  If unchecked, explain why it's not needed 
-->


- [X] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [X] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

- [x] Gosec scans
  <!-- _Review scan results from the PR.  Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue_-->


### How to test changes / Special notes to the reviewer:

Use `Go 1.21.10` under an [Ubuntu Server 22.04 LTS](https://releases.ubuntu.com/22.04/ubuntu-22.04.4-live-server-amd64.iso) instances and run:

```
make test
```
