### PR TITLE
update distribution/reference import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/devfile/api/v2 v2.3.0
 	github.com/devfile/registry-support/registry-library v0.0.0-20240521161747-89fc566cb024
-	github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2
+	github.com/distribution/reference v0.6.0
 	github.com/fatih/color v1.14.1
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-git/go-git/v5 v5.13.0
@@ -47,7 +47,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/devfile/registry-support/index/generator v0.0.0-20240419194226-cca4c9a81f8d // indirect
-	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/cli v25.0.1+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v25.0.6+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/devfile/registry-support/registry-library v0.0.0-20240521161747-89fc5
 github.com/devfile/registry-support/registry-library v0.0.0-20240521161747-89fc566cb024/go.mod h1:0IbIyxWGz+Mehw5kDIF5wSE/MoStF1jeRplt3TGc8oI=
 github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2 h1:aBfCb7iqHmDEIp6fBvC/hQUddQfg+3qdYjwzaiP9Hnc=
 github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2/go.mod h1:WHNsWjnIn2V1LYOrME7e8KxSeKunYHsxEm4am0BUtcI=
-github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
-github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v25.0.1+incompatible h1:mFpqnrS6Hsm3v1k7Wa/BO23oz0k121MTbTO1lpcGSkU=
 github.com/docker/cli v25.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=

--- a/pkg/devfile/imageNameSelector.go
+++ b/pkg/devfile/imageNameSelector.go
@@ -25,7 +25,7 @@ import (
 	v1 "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/library/v2/pkg/devfile/parser"
 	"github.com/devfile/library/v2/pkg/devfile/parser/data/v2/common"
-	"github.com/distribution/distribution/v3/reference"
+	"github.com/distribution/reference"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
# Description of Changes
_Summarize the changes you made as part of this pull request._

- update distribution/reference to v0.6.0
- update "github.com/distribution/distribution/v3/reference" imports to "github.com/distribution/reference"

# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

https://github.com/openshift/console/pull/14841

# Acceptance Criteria
no code changes. I am just updating an import as [distribution/v3/reference](https://pkg.go.dev/github.com/distribution/distribution/v3/reference) does not appear to be a valid go import. this is causing some error in openshift console:

```
go: finding module for package github.com/distribution/distribution/v3/reference
go: github.com/openshift/console/pkg/devfile imports
	github.com/devfile/library/v2/pkg/devfile imports
	github.com/distribution/distribution/v3/reference: module github.com/distribution/distribution/v3@latest found (v3.0.0), but does not contain package github.com/distribution/distribution/v3/reference
```
