### PR TITLE
Updating go version 1.24, fixing linting errors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -81,7 +81,7 @@ jobs:
 
     - name: Run Gosec Security Scanner
       run: |
-        go install github.com/securego/gosec/v2/cmd/gosec@v2.14.0
+        go install github.com/securego/gosec/v2/cmd/gosec@v2.22.7
         make gosec
         if [[ $? != 0 ]]
         then

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -70,7 +70,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ contribution. See the [DCO](./DCO) file for details.
 The following are required to work on devfile library:
 
 - Git
-- Go 1.21 or later
+- Go 1.24 or later
 
 ## Code of Conduct
 Before contributing to this repository, see [contributor code of conduct](https://github.com/devfile/api/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div id="header">
 
-![Go](https://img.shields.io/badge/Go-1.21-blue)
+![Go](https://img.shields.io/badge/Go-1.24-blue)
 [![Apache2.0 License](https://img.shields.io/badge/license-Apache2.0-brightgreen.svg)](LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8231/badge)](https://www.bestpractices.dev/projects/8231)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/devfile/library/badge)](https://securityscorecards.dev/viewer/?uri=github.com/devfile/library)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/library/v2
 
-go 1.21
+go 1.24
 
 require (
 	github.com/devfile/api/v2 v2.3.0

--- a/pkg/devfile/generator/generators_test.go
+++ b/pkg/devfile/generator/generators_test.go
@@ -358,7 +358,7 @@ func TestGetContainers(t *testing.T) {
 				mockGetComponents.Return(tt.filteredComponents, nil).AnyTimes()
 			}
 			if tt.wantErr != nil {
-				mockGetComponents.Return(nil, fmt.Errorf(*tt.wantErr))
+				mockGetComponents.Return(nil, fmt.Errorf("%s", *tt.wantErr))
 			}
 			mockDevfileData.EXPECT().GetProjects(common.DevfileOptions{}).Return(projects, nil).AnyTimes()
 
@@ -635,7 +635,7 @@ func TestGetVolumesAndVolumeMounts(t *testing.T) {
 
 			if tt.wantErr != nil {
 				// simulate error condition
-				mockGetContainerComponents.Return(nil, fmt.Errorf(*tt.wantErr))
+				mockGetContainerComponents.Return(nil, fmt.Errorf("%s", *tt.wantErr))
 
 			}
 
@@ -878,7 +878,7 @@ func TestGetInitContainers(t *testing.T) {
 			mockGetCommands.Return(append(applyCommands, compCommands...), nil).AnyTimes()
 
 			if tt.wantErr != nil {
-				mockGetCommands.Return(nil, fmt.Errorf(*tt.wantErr)).AnyTimes()
+				mockGetCommands.Return(nil, fmt.Errorf("%s", *tt.wantErr)).AnyTimes()
 			}
 
 			devObj := parser.DevfileObj{

--- a/pkg/devfile/parser/data/helper.go
+++ b/pkg/devfile/parser/data/helper.go
@@ -35,8 +35,7 @@ func NewDevfileData(version string) (obj DevfileData, err error) {
 	// Fetch devfile struct type from map
 	devfileType, ok := apiVersionToDevfileStruct[supportedApiVersion(version)]
 	if !ok {
-		errMsg := fmt.Sprintf("devfile type not present for apiVersion '%s'", version)
-		return obj, fmt.Errorf(errMsg)
+		return obj, fmt.Errorf("devfile type not present for apiVersion '%s'", version)
 	}
 
 	return reflect.New(devfileType).Interface().(DevfileData), nil

--- a/pkg/devfile/parser/utils.go
+++ b/pkg/devfile/parser/utils.go
@@ -96,16 +96,14 @@ func GetImageBuildComponent(devfileData data.DevfileData, deployAssociatedCompon
 			if reflect.DeepEqual(imageBuildComponent, devfilev1.Component{}) {
 				imageBuildComponent = component
 			} else {
-				errMsg := "expected to find one devfile image component with a deploy command for build. Currently there is more than one image component"
-				return devfilev1.Component{}, fmt.Errorf(errMsg)
+				return devfilev1.Component{}, fmt.Errorf("expected to find one devfile image component with a deploy command for build. Currently there is more than one image component")
 			}
 		}
 	}
 
 	// If there is not one image component defined in the deploy command, err out
 	if reflect.DeepEqual(imageBuildComponent, devfilev1.Component{}) {
-		errMsg := "expected to find one devfile image component with a deploy command for build. Currently there is no image component"
-		return devfilev1.Component{}, fmt.Errorf(errMsg)
+		return devfilev1.Component{}, fmt.Errorf("expected to find one devfile image component with a deploy command for build. Currently there is no image component")
 	}
 
 	return imageBuildComponent, nil

--- a/pkg/devfile/parser/utils_test.go
+++ b/pkg/devfile/parser/utils_test.go
@@ -178,7 +178,7 @@ func TestGetDeployComponents(t *testing.T) {
 			mockDeployCommands := mockDevfileData.EXPECT().GetCommands(deployCommandFilter)
 			mockDeployCommands.Return(tt.deployCommands, nil).AnyTimes()
 			if tt.wantMockErr1 != nil {
-				mockDeployCommands.Return(nil, fmt.Errorf(*tt.wantMockErr1))
+				mockDeployCommands.Return(nil, fmt.Errorf("%s", *tt.wantMockErr1))
 			}
 
 			applyCommandFilter := common.DevfileOptions{
@@ -189,7 +189,7 @@ func TestGetDeployComponents(t *testing.T) {
 			mockApplyCommands := mockDevfileData.EXPECT().GetCommands(applyCommandFilter)
 			mockApplyCommands.Return(tt.applyCommands, nil).AnyTimes()
 			if tt.wantMockErr2 != nil {
-				mockApplyCommands.Return(nil, fmt.Errorf(*tt.wantMockErr2))
+				mockApplyCommands.Return(nil, fmt.Errorf("%s", *tt.wantMockErr2))
 			}
 
 			componentMap, err := GetDeployComponents(mockDevfileData)
@@ -361,7 +361,7 @@ func TestGetImageBuildComponent(t *testing.T) {
 			// set up the mock data
 			mockGetComponents.Return(tt.components, nil).AnyTimes()
 			if tt.wantMockErr != nil {
-				mockGetComponents.Return(nil, fmt.Errorf(*tt.wantMockErr))
+				mockGetComponents.Return(nil, fmt.Errorf("%s", *tt.wantMockErr))
 			}
 
 			component, err := GetImageBuildComponent(mockDevfileData, tt.deployAssociatedComponents)

--- a/tests/v2/utils/library/test_utils.go
+++ b/tests/v2/utils/library/test_utils.go
@@ -297,7 +297,7 @@ func CopyDevfileSamples(t *testing.T, testDevfiles []string) {
 
 		file, err := os.Stat(srcPath)
 		if err != nil {
-			t.Fatalf(commonUtils.LogErrorMessage(fmt.Sprintf("Error locating testDevfile %v ", err)))
+			t.Fatalf("%s", commonUtils.LogErrorMessage(fmt.Sprintf("Error locating testDevfile %v ", err)))
 		} else {
 			commonUtils.LogMessage(fmt.Sprintf("copy file from %s to %s ", srcPath, destPath))
 			util.CopyFile(srcPath, destPath, file)
@@ -312,7 +312,7 @@ func duplicateDevfileSample(t *testing.T, src string, dst string) {
 	destPath := destDir + dst
 	file, err := os.Stat(srcPath)
 	if err != nil {
-		t.Fatalf(commonUtils.LogErrorMessage(fmt.Sprintf("Error locating testDevfile %v ", err)))
+		t.Fatalf("%s", commonUtils.LogErrorMessage(fmt.Sprintf("Error locating testDevfile %v ", err)))
 	} else {
 		commonUtils.LogMessage(fmt.Sprintf("duplicate file %s to %s ", srcPath, destPath))
 		util.CopyFile(srcPath, destDir+dst, file)
@@ -332,7 +332,7 @@ func RunTest(testContent commonUtils.TestContent, t *testing.T) {
 		follower := DevfileFollower{}
 		libraryData, err := devfileData.NewDevfileData(schemaVersion)
 		if err != nil {
-			t.Fatalf(commonUtils.LogMessage(fmt.Sprintf("Error creating parser data : %v", err)))
+			t.Fatalf("%s", commonUtils.LogMessage(fmt.Sprintf("Error creating parser data : %v", err)))
 		}
 		libraryData.SetSchemaVersion(schemaVersion)
 		follower.LibraryData = libraryData
@@ -340,7 +340,7 @@ func RunTest(testContent commonUtils.TestContent, t *testing.T) {
 
 		testDevfile, err := commonUtils.GetDevfile(testContent.FileName, follower, validator)
 		if err != nil {
-			t.Fatalf(commonUtils.LogMessage(fmt.Sprintf("Error creating devfile : %v", err)))
+			t.Fatalf("%s", commonUtils.LogMessage(fmt.Sprintf("Error creating devfile : %v", err)))
 		}
 
 		testDevfile.RunTest(testContent, t)
@@ -349,25 +349,25 @@ func RunTest(testContent commonUtils.TestContent, t *testing.T) {
 			if len(testContent.CommandTypes) > 0 {
 				err = editCommands(&testDevfile)
 				if err != nil {
-					t.Fatalf(commonUtils.LogErrorMessage(fmt.Sprintf("ERROR editing commands :  %s : %v", testContent.FileName, err)))
+					t.Fatalf("%s", commonUtils.LogErrorMessage(fmt.Sprintf("ERROR editing commands :  %s : %v", testContent.FileName, err)))
 				}
 			}
 			if len(testContent.ComponentTypes) > 0 {
 				err = editComponents(&testDevfile)
 				if err != nil {
-					t.Fatalf(commonUtils.LogErrorMessage(fmt.Sprintf("ERROR editing components :  %s : %v", testContent.FileName, err)))
+					t.Fatalf("%s", commonUtils.LogErrorMessage(fmt.Sprintf("ERROR editing components :  %s : %v", testContent.FileName, err)))
 				}
 			}
 			if len(testContent.ProjectTypes) > 0 {
 				err = editProjects(&testDevfile)
 				if err != nil {
-					t.Fatalf(commonUtils.LogErrorMessage(fmt.Sprintf("ERROR editing projects :  %s : %v", testContent.FileName, err)))
+					t.Fatalf("%s", commonUtils.LogErrorMessage(fmt.Sprintf("ERROR editing projects :  %s : %v", testContent.FileName, err)))
 				}
 			}
 			if len(testContent.StarterProjectTypes) > 0 {
 				err = editStarterProjects(&testDevfile)
 				if err != nil {
-					t.Fatalf(commonUtils.LogErrorMessage(fmt.Sprintf("ERROR editing starter projects :  %s : %v", testContent.FileName, err)))
+					t.Fatalf("%s", commonUtils.LogErrorMessage(fmt.Sprintf("ERROR editing starter projects :  %s : %v", testContent.FileName, err)))
 				}
 			}
 
@@ -386,7 +386,7 @@ func RunStaticTest(testContent commonUtils.TestContent, t *testing.T) {
 	testDevfile.SchemaDevFile.Parent = &schema.Parent{}
 	err := validateDevfile(&testDevfile)
 	if err != nil {
-		t.Fatalf(commonUtils.LogErrorMessage(fmt.Sprintf("Error validating testDevfile %v ", err)))
+		t.Fatalf("%s", commonUtils.LogErrorMessage(fmt.Sprintf("Error validating testDevfile %v ", err)))
 	}
 }
 


### PR DESCRIPTION
# Description of Changes
Updating go version from 1.21 to 1.24
Needed some linting changes (error output format) to keep up with 1.24 rules. 

# Related Issue(s)
https://github.com/devfile/api/issues/1699

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->
_Testing and documentation do not need to be complete in order for this PR to be approved. However, tracking issues must be opened for missing testing/documentation._

New testing and documentation issues can be opened under [`devfile/api/issues`](https://github.com/devfile/api/issues).

You can check the respective criteria below if either of the following is true:
- There is a separate tracking issue opened and that issue is linked in this PR.
- Testing/documentation updates are contained within this PR.

If criteria is left unchecked please provide an explanation why.


- [o] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [o] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [o] Documentation (READMEs, Product Docs, Blogs, Education Modules, etc.)

   <!-- _This includes READMEs, Product Docs, Blogs, Education Modules, etc._ -->
